### PR TITLE
Offer retries in tests and update selenium-assistant

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mocha": "^2.4.5",
     "portfinder": "^1.0.2",
     "request": "^2.69.0",
-    "selenium-assistant": "0.1.5",
+    "selenium-assistant": "0.2.0",
     "selenium-webdriver": "~2.53.2",
     "semver": "^5.1.0",
     "temp": "^0.8.3",

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -194,7 +194,9 @@
         })
         .then(function() {
           var expectedTitle = options.payload ? options.payload : 'no payload';
-          return globalDriver.wait(webdriver.until.titleIs(expectedTitle, 60000));
+          return globalDriver.wait(function() {
+            return webdriver.until.titleIs(expectedTitle, 60000);
+          });
         })
         .then(function() {
           resolve();
@@ -216,6 +218,7 @@
     }
 
     suite('Selenium ' + browser.getPrettyName(), function() {
+      this.retries(3);
 
       setup(function() {
         globalServer = null;


### PR DESCRIPTION
This makes tests retry up to 3 times before being classed as failed - this is handy given the selenium tests can fail from time to time. Should make Travis more reliable. Also updated selenium-assistant to work with the latest changes to geckodriver release.