### PR TITLE
Allow overriding GCM API key with a sendNotification argument.

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,8 @@ function sendNotification(endpoint, params) {
 
   return new Promise(function(resolve, reject) {
     try {
+      var curGCMAPIKey = gcmAPIKey;
+
       if (args.length === 0) {
         throw new Error('sendNotification requires at least one argument, the endpoint URL.');
       } else if (params && typeof params === 'object') {
@@ -139,6 +141,9 @@ function sendNotification(endpoint, params) {
         var userAuth = params.userAuth;
         var payload = params.payload;
         var vapid = params.vapid;
+        if (params.gcmAPIKey) {
+          curGCMAPIKey = params.gcmAPIKey;
+        }
       } else if (args.length !== 1) {
         throw new Error('You are using the old, deprecated, interface of the `sendNotification` function.');
       }
@@ -187,11 +192,11 @@ function sendNotification(endpoint, params) {
 
       var isGCM = endpoint.indexOf('https://android.googleapis.com/gcm/send') === 0;
       if (isGCM) {
-        if (!gcmAPIKey) {
+        if (!curGCMAPIKey) {
           console.warn('Attempt to send push notification to GCM endpoint, but no GCM key is defined'.bold.red);
         }
 
-        options.headers['Authorization'] = 'key=' + gcmAPIKey;
+        options.headers['Authorization'] = 'key=' + curGCMAPIKey;
       }
 
       if (vapid && !isGCM) {

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -356,6 +356,34 @@ suite('sendNotification', function() {
     });
   });
 
+  test('send/receive string with GCM (overriding the GCM API key)', function() {
+    var httpsrequest = https.request;
+    https.request = function(options, listener) {
+      options.hostname = '127.0.0.1';
+      options.port = serverPort;
+      options.path = '/';
+      return httpsrequest.call(https, options, listener);
+    }
+
+    webPush.setGCMAPIKey('another_gcm_api_key');
+
+    return startServer('hello', undefined, undefined, true)
+    .then(function() {
+      return webPush.sendNotification('https://android.googleapis.com/gcm/send/someSubscriptionID', {
+        userPublicKey: urlBase64.encode(userPublicKey),
+        userAuth: urlBase64.encode(userAuth),
+        payload: 'hello',
+        gcmAPIKey: 'my_gcm_key',
+      });
+    })
+    .then(function(body) {
+      assert(true, 'sendNotification promise resolved');
+      assert.equal(body, 'ok');
+    }, function() {
+      assert(false, 'sendNotification promise rejected');
+    });
+  });
+
   test('0 arguments', function() {
     return webPush.sendNotification()
     .then(function() {


### PR DESCRIPTION
Fixes #181.