### PR TITLE
Remove reference to binary and no longer used minimist package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "2.2.0",
   "description": "Web Push library for Node.js",
   "main": "src/index.js",
-  "bin": {
-    "web-push": "bin/web-push.js"
-  },
   "scripts": {
     "download-browser": "node --harmony ./test/helpers/download-test-browsers.js",
     "lint": "node ./node_modules/eslint/bin/eslint --ignore-path .gitignore '.'",
@@ -37,7 +34,6 @@
     "create-ecdh": "^4.0.0",
     "http_ece": "^0.5.1",
     "jws": "^3.1.3",
-    "minimist": "^1.2.0",
     "urlsafe-base64": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We've removed the binary in #196, but no one has complained. I think we can avoid to reintroduce it and save a bit of space (helping #207) by removing the `minimist` package.