### PR TITLE
Add more files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
 coverage
 test
 test_tools
-
+.travis.yml
+wires
+.eslintrc


### PR DESCRIPTION
This will save a few bytes and will help me remember not to package the `wires` executable.