### PR TITLE
Expose WebPushError as a public API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,12 @@
 const vapidHelper = require('./vapid-helper.js');
 const encryptionHelper = require('./encryption-helper.js');
 const WebPushLib = require('./web-push-lib.js');
+const WebPushError = require('./web-push-error.js');
 
 const webPush = new WebPushLib();
 
 module.exports = {
+  WebPushError: WebPushError,
   encrypt: encryptionHelper.encrypt,
   getVapidHeaders: vapidHelper.getVapidHeaders,
   generateVAPIDKeys: vapidHelper.generateVAPIDKeys,


### PR DESCRIPTION
This can be helpful in identifying errors, such as `err instanceof WebPushError`, etc. For your consideration!