### PR TITLE
Replaced hostname with host

### DIFF
--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -205,7 +205,7 @@ WebPushLib.prototype.generateRequestDetails =
     } else if (currentVapidDetails) {
       const parsedUrl = url.parse(subscription.endpoint);
       const audience = parsedUrl.protocol + '//' +
-        parsedUrl.hostname;
+        parsedUrl.host;
 
       const vapidHeaders = vapidHelper.getVapidHeaders(
         audience,


### PR DESCRIPTION
Google says in their developer pages
> This is the origin of the push service (NOT the origin of your site). In JavaScript, you could do the following to get the audience: const audience = new URL(subscription.endpoint).origin

[Source](https://developers.google.com/web/updates/2016/07/web-push-interop-wins#sending_a_push_message)

W3C says (at least in W3CSchools)
> Return the protocol, hostname and port number of a URL.

[Source](http://www.w3schools.com/jsref/prop_loc_origin.asp)

I guess, the old line would cause problems, if a browser vendor decided to run their endpoint service somewhere else than port 80 or 443.