### PR TITLE
adding request to support HTTPS_PROXY

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "http_ece": "^0.5.2",
     "jws": "^3.1.3",
     "minimist": "^1.2.0",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.4",
     "urlsafe-base64": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Not the most elegant way to solve https://github.com/web-push-libs/web-push/issues/280 but adds common used npm request to provide solid request options and HTTPS_PROXY env support.