### PR TITLE
Add option to add Custom Expiration

### DIFF
--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -205,5 +205,6 @@ module.exports = {
   getVapidHeaders: getVapidHeaders,
   validateSubject: validateSubject,
   validatePublicKey: validatePublicKey,
-  validatePrivateKey: validatePrivateKey
+  validatePrivateKey: validatePrivateKey,
+  validateExpiration: validateExpiration
 };

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -128,9 +128,9 @@ function validateExpiration(expiration) {
 
   // Roughly checks the time of expiration, since the max expiration can be ahead
   // of the time than at the moment the expiration was generated
-  const maxExpiration = getFutureExpirationTimestamp(MAX_EXPIRATION_SECONDS);
+  const maxExpirationTimestamp = getFutureExpirationTimestamp(MAX_EXPIRATION_SECONDS);
 
-  if (expiration >= maxExpiration) {
+  if (expiration >= maxExpirationTimestamp) {
     throw new Error('`expiration` value is greater than maximum of 24 hours');
   }
 }

--- a/test/test-vapid-helper.js
+++ b/test/test-vapid-helper.js
@@ -85,6 +85,18 @@ suite('Test Vapid Helpers', function() {
       },
       function() {
         vapidHelper.getVapidHeaders(VALID_AUDIENCE, { something: 'else' }, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY);
+      },
+      function () {
+        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, 'This is not valid expiration');
+      },
+      function () {
+        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, { message: 'Expiration should be a number' });
+      },
+      function () {
+        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, 'true');
+      },
+      function () {
+        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, '-12213');
       }
     ];
 
@@ -109,6 +121,12 @@ suite('Test Vapid Helpers', function() {
       function() {
         return vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_URL,
           VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, VALID_EXPIRATION);
+      },
+      function() {
+        return vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_URL, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, 0);
+      },
+      function () {
+        return vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_URL, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, Math.floor(Date.now() / 1000) + (5 * 60 * 60));
       }
     ];
 

--- a/test/test-vapid-helper.js
+++ b/test/test-vapid-helper.js
@@ -101,6 +101,11 @@ suite('Test Vapid Helpers', function() {
       function () {
         // String is not accepted as a valid expiration value
         vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, '12213');
+      },
+      function () {
+        // Invalid `expiration` as it exceeds 24 hours in duration
+        const invalidExpiration = Math.floor(Date.now() / 1000) + (25 * 60 * 60);
+        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, invalidExpiration);
       }
     ];
 

--- a/test/test-vapid-helper.js
+++ b/test/test-vapid-helper.js
@@ -87,16 +87,20 @@ suite('Test Vapid Helpers', function() {
         vapidHelper.getVapidHeaders(VALID_AUDIENCE, { something: 'else' }, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY);
       },
       function () {
-        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, 'This is not valid expiration');
+        // String with text, is not accepted as a valid expiration value
+        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, 'Not valid expiration: Must be a number, this is a string with text');
       },
       function () {
-        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, { message: 'Expiration should be a number' });
+        // Object is not accepted as a valid expiration value
+        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, { message: 'Not valid expiration: Must be a number, this is an object' });
       },
       function () {
-        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, 'true');
+        // Boolean is not accepted as a valid expiration value
+        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, true);
       },
       function () {
-        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, '-12213');
+        // String is not accepted as a valid expiration value
+        vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, '12213');
       }
     ];
 
@@ -123,10 +127,16 @@ suite('Test Vapid Helpers', function() {
           VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, VALID_EXPIRATION);
       },
       function() {
-        return vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_URL, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, 0);
+        // 0 is a valid value for `expiration`
+        // since the the `expiration` value isn't checked for minimum
+        const secondsFromEpoch = 0;
+        return vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_URL, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, secondsFromEpoch);
       },
       function () {
-        return vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_URL, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, Math.floor(Date.now() / 1000) + (5 * 60 * 60));
+        // Valid value for `secondsFromEpoch` passed in to
+        // `vapidHelper.getVapidHeaders` function
+        const secondsFromEpoch = Math.floor(Date.now() / 1000) + (5 * 60 * 60);
+        return vapidHelper.getVapidHeaders(VALID_AUDIENCE, VALID_SUBJECT_URL, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY, secondsFromEpoch);
       }
     ];
 


### PR DESCRIPTION
This PR let's the people add Custom Expiration to their vapid headers, but it seems expiration is a completed part and this is just the initial PR, the validation of the expiration can be more complex too.

The `validateExpiration` does not check the time for the minimum since minimums can be different in all points of time.

### Are there tests?

I have added a basic test suite of valid and invalid expiration examples, following the pattern in `test-vapid-helpers.js`, if  there are updates to be made, please himmeup with a comment.

## Some Questions

### Timezone Differences

Date.now() returns time in UTC since UNIX Epoch as we all know. Are we guaranteed the push service is going to parse this in the UTC and not other timezone? The expiry parsing on the Push Service shouldn't be dependent on the timezone of the Server?

UPDATE: It's guaranteed to be [NumericDate](https://tools.ietf.org/html/rfc7519#page-6) which is in UTC and is the number of seconds since UNIX Epoch. 

### Updating expiry value everytime?

If a custom `expiration` value is not specified, it's going to update like every time we call the function, there's no benefit to it, since it gets updated by some time, even if seconds. Can we create a new expiration only once the one we currently generated is no longer valid?