### PR TITLE
Don't manually install mocha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
   - export NPM=${NODE%node}npm
 install:
   - $NPM install
-  - $NPM install mocha
 before_script:
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
 script:


### PR DESCRIPTION
I don't know why we were manually installing it since it is in package.json. Since this manual installation makes builds fail with the latest version of Node, let's avoid it.