### PR TITLE
Add aes128gcm support for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Then you can run the following commands:
 
     Usage:
 
-      web-push send-notification --endpoint=<url> [--key=<browser key>] [--auth=<auth secret>] [--payload=<message>] [--ttl=<seconds>] [--vapid-subject=<vapid subject>] [--vapid-pubkey=<public key url base64>] [--vapid-pvtkey=<private key url base64>] [--gcm-api-key=<api key>]
+      web-push send-notification --endpoint=<url> [--key=<browser key>] [--auth=<auth secret>] [--payload=<message>] [--encoding=<aesgcm | aes128gcm>] [--ttl=<seconds>] [--vapid-subject=<vapid subject>] [--vapid-pubkey=<public key url base64>] [--vapid-pvtkey=<private key url base64>] [--gcm-api-key=<api key>]
 
       web-push generate-vapid-keys [--json]
 

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -93,6 +93,7 @@
           '--auth=auth',
           '--payload=hello',
           '--ttl=1234',
+          '--encoding=aesgcm',
           '--vapid-subject=http://example.push-serice.com/contact',
           '--vapid-pubkey=vapid-publicKey',
           '--vapid-pvtkey=vapid-privateKey',


### PR DESCRIPTION
I already added the support for CLI in the previous PR, but I didn't update the docs and test. This PR updates the docs and the test.