### PR TITLE
Remove useless escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ which you can do like so:
 function urlBase64ToUint8Array(base64String) {
   const padding = '='.repeat((4 - base64String.length % 4) % 4);
   const base64 = (base64String + padding)
-    .replace(/\-/g, '+')
+    .replace(/-/g, '+')
     .replace(/_/g, '/');
 
   const rawData = window.atob(base64);


### PR DESCRIPTION
Escaping non-special characters in regular expressions doesn’t have any effect.