### PR TITLE
Allow falsy values for vapidDetails

### DIFF
--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -148,7 +148,8 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
         currentGCMAPIKey = options.gcmAPIKey;
       }
 
-      if (options.vapidDetails) {
+      // Falsy values are allowed here so one can skip Vapid `else if` below and use FCM
+      if (options.vapidDetails !== undefined) {
         currentVapidDetails = options.vapidDetails;
       }
 

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -191,14 +191,13 @@ suite('sendNotification', function() {
         [jwt, vapidKey] = authorizationHeader.substring('vapid t='.length).split(', k=');
       }
 
-      // const appServerVapidPublicKey = urlBase64.decode(vapidKey);
       assert.equal(vapidKey, vapidKeys.publicKey);
 
       // assert(jws.verify(jwt, 'ES256', appServerVapidPublicKey)), 'JWT valid');
        const decoded = jws.decode(jwt);
        assert.equal(decoded.header.typ, 'JWT');
        assert.equal(decoded.header.alg, 'ES256');
-       assert.equal(options.subscription.endpoint.indexOf(decoded.payload.aud) === 0, true);
+       assert.equal(options.subscription.endpoint.startsWith(decoded.payload.aud), true);
        assert(decoded.payload.exp > Date.now() / 1000);
        assert.equal(decoded.payload.sub, 'mailto:mozilla@example.org');
     }

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -131,6 +131,8 @@ suite('sendNotification', function() {
       || WebPushConstants.supportedContentEncodings.AES_GCM;
     const isGCM = options.subscription.endpoint
       .indexOf('https://android.googleapis.com/gcm') === 0;
+    const isFCM = options.subscription.endpoint
+    .indexOf('https://fcm.googleapis.com/fcm') === 0;
 
     assert.equal(requestDetails.headers['content-length'], requestBody.length, 'Check Content-Length header');
 
@@ -201,7 +203,7 @@ suite('sendNotification', function() {
       assert.equal(decoded.payload.sub, 'mailto:mozilla@example.org');
     }
 
-    if (isGCM) {
+    if (isGCM || (isFCM && !options.vapid)) {
       if (typeof options.extraOptions !== 'undefined'
       && typeof options.extraOptions.gcmAPIKey !== 'undefined') {
         assert.equal(requestDetails.headers.authorization, 'key=' + options.extraOptions.gcmAPIKey, 'Check GCM Authorization header');

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -465,8 +465,22 @@ suite('sendNotification', function() {
         validGCMRequest.requestOptions.subscription.endpoint = 'https://android.googleapis.com/gcm/send/someSubscriptionID';
       }
 
+      validGCMRequest.globalOptions = validGCMRequest.globalOptions || {};
+      if (validGCMRequest.globalOptions.gcmAPIKey === undefined) {
+        validGCMRequest.globalOptions.gcmAPIKey = 'my_gcm_key';
+      }
+
       const webPush = require('../src/index');
-      webPush.setGCMAPIKey('my_gcm_key');
+      if (validGCMRequest.globalOptions.gcmAPIKey) {
+        webPush.setGCMAPIKey(validGCMRequest.globalOptions.gcmAPIKey);
+      }
+      if (validGCMRequest.globalOptions.vapidDetails) {
+        webPush.setVapidDetails(
+          validGCMRequest.globalOptions.vapidDetails.subject,
+          validGCMRequest.globalOptions.vapidDetails.publicKey,
+          validGCMRequest.globalOptions.vapidDetails.privateKey
+        );
+      }
 
       return webPush.sendNotification(
         validGCMRequest.requestOptions.subscription,

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -174,16 +174,16 @@ suite('sendNotification', function() {
       let vapidKey;
 
       if (contentEncoding === WebPushConstants.supportedContentEncodings.AES_GCM) {
-      const keys = requestDetails.headers['crypto-key'].split(';');
+        const keys = requestDetails.headers['crypto-key'].split(';');
         const vapidKeyHeader = keys.find(function(key) {
-        return key.indexOf('p256ecdsa=') === 0;
-      });
+          return key.indexOf('p256ecdsa=') === 0;
+        });
 
         assert.equal(vapidKeyHeader.indexOf('p256ecdsa='), 0, 'Crypto-Key header correct');
         vapidKey = vapidKeyHeader.substring('p256ecdsa='.length);
 
-      const authorizationHeader = requestDetails.headers.authorization;
-      assert.equal(authorizationHeader.indexOf('WebPush '), 0, 'Check VAPID Authorization header');
+        const authorizationHeader = requestDetails.headers.authorization;
+        assert.equal(authorizationHeader.indexOf('WebPush '), 0, 'Check VAPID Authorization header');
         jwt = authorizationHeader.substring('WebPush '.length);
       } else if (contentEncoding === WebPushConstants.supportedContentEncodings.AES_128_GCM) {
         const authorizationHeader = requestDetails.headers.authorization;
@@ -195,12 +195,12 @@ suite('sendNotification', function() {
       assert.equal(vapidKey, vapidKeys.publicKey);
 
       // assert(jws.verify(jwt, 'ES256', appServerVapidPublicKey)), 'JWT valid');
-      const decoded = jws.decode(jwt);
-      assert.equal(decoded.header.typ, 'JWT');
-      assert.equal(decoded.header.alg, 'ES256');
+       const decoded = jws.decode(jwt);
+       assert.equal(decoded.header.typ, 'JWT');
+       assert.equal(decoded.header.alg, 'ES256');
        assert.equal(options.subscription.endpoint.indexOf(decoded.payload.aud) === 0, true);
-      assert(decoded.payload.exp > Date.now() / 1000);
-      assert.equal(decoded.payload.sub, 'mailto:mozilla@example.org');
+       assert(decoded.payload.exp > Date.now() / 1000);
+       assert.equal(decoded.payload.sub, 'mailto:mozilla@example.org');
     }
 
     if (isGCM || (isFCM && !options.vapid)) {
@@ -411,6 +411,102 @@ suite('sendNotification', function() {
       testTitle: 'send/receive GCM',
       requestOptions: {
         subscription: {
+        }
+      }
+    }, {
+      testTitle: 'send/receive FCM',
+      requestOptions: {
+        subscription: {
+          endpoint: 'https://fcm.googleapis.com/fcm/send/someSubscriptionID'
+        }
+      }
+    }, {
+      testTitle: 'send/receive FCM and you want to use VAPID (aesgcm)',
+      requestOptions: {
+        subscription: {
+          endpoint: 'https://fcm.googleapis.com/fcm/send/someSubscriptionID',
+          keys: VALID_KEYS
+        },
+        extraOptions: {
+          vapidDetails: {
+            subject: 'mailto:mozilla@example.org',
+            privateKey: vapidKeys.privateKey,
+            publicKey: vapidKeys.publicKey
+          },
+          contentEncoding: WebPushConstants.supportedContentEncodings.AES_GCM
+        },
+        vapid: true
+      }
+    }, {
+      testTitle: 'send/receive FCM and you want to use VAPID (aesgcm) (via global options)',
+      requestOptions: {
+        subscription: {
+          endpoint: 'https://fcm.googleapis.com/fcm/send/someSubscriptionID',
+          keys: VALID_KEYS
+        },
+        extraOptions: {
+          contentEncoding: WebPushConstants.supportedContentEncodings.AES_GCM
+        },
+        vapid: true
+      },
+      globalOptions: {
+        vapidDetails: {
+          subject: 'mailto:mozilla@example.org',
+          privateKey: vapidKeys.privateKey,
+          publicKey: vapidKeys.publicKey
+        }
+      }
+    }, {
+      testTitle: 'send/receive FCM and you want to use VAPID (aes128gcm)',
+      requestOptions: {
+        subscription: {
+          endpoint: 'https://fcm.googleapis.com/fcm/send/someSubscriptionID',
+          keys: VALID_KEYS
+        },
+        extraOptions: {
+          vapidDetails: {
+            subject: 'mailto:mozilla@example.org',
+            privateKey: vapidKeys.privateKey,
+            publicKey: vapidKeys.publicKey
+          },
+          contentEncoding: WebPushConstants.supportedContentEncodings.AES_128_GCM
+        },
+        vapid: true
+      }
+    }, {
+      testTitle: 'send/receive FCM and you want to use VAPID (aes128gcm) (via global options)',
+      requestOptions: {
+        subscription: {
+          endpoint: 'https://fcm.googleapis.com/fcm/send/someSubscriptionID',
+          keys: VALID_KEYS
+        },
+        extraOptions: {
+          contentEncoding: WebPushConstants.supportedContentEncodings.AES_128_GCM
+        },
+        vapid: true
+      },
+      globalOptions: {
+        vapidDetails: {
+          subject: 'mailto:mozilla@example.org',
+          privateKey: vapidKeys.privateKey,
+          publicKey: vapidKeys.publicKey
+        }
+      }
+    }, {
+      testTitle: 'send/receive FCM and you don\'t want to use VAPID (when global options set)',
+      requestOptions: {
+        subscription: {
+          endpoint: 'https://fcm.googleapis.com/fcm/send/someSubscriptionID'
+        },
+        extraOptions: {
+          vapidDetails: null
+        }
+      },
+      globalOptions: {
+        vapidDetails: {
+          subject: 'mailto:mozilla@example.org',
+          privateKey: vapidKeys.privateKey,
+          publicKey: vapidKeys.publicKey
         }
       }
     }, {


### PR DESCRIPTION
Closes #445 

I added some tests for multiple FCM cases, but I had to fix the vapid validation for that. Please review those changes once.

Also should I separate the tests for FCM from current GCM tests?