### PR TITLE
Add https.agent options

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ const options = {
     '< header name >': '< header value >'
   },
   contentEncoding: '< Encoding type, e.g.: aesgcm or aes128gcm >',
-  proxy: '< proxy server options >'
+  proxy: '< proxy server options >',
+  agent: '< https.Agent instance >'
 }
 
 webpush.sendNotification(
@@ -185,6 +186,7 @@ retained by the push service (by default, four weeks).
 - **proxy** is the [HttpsProxyAgent's constructor argument](https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-options)
 that may either be a string URI of the proxy server (eg. http://< hostname >:< port >)
 or an "options" object with more specific properties.
+- **agent** is the [HTTPS Agent instance](https://nodejs.org/dist/latest-v12.x/docs/api/https.html#https_class_https_agent) which will be used in `https.request` method. If `proxy` options defined, agent will be ignored!
 
 ### Returns
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ retained by the push service (by default, four weeks).
 - **proxy** is the [HttpsProxyAgent's constructor argument](https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-options)
 that may either be a string URI of the proxy server (eg. http://< hostname >:< port >)
 or an "options" object with more specific properties.
-- **agent** is the [HTTPS Agent instance](https://nodejs.org/dist/latest-v12.x/docs/api/https.html#https_class_https_agent) which will be used in `https.request` method. If `proxy` options defined, agent will be ignored!
+- **agent** is the [HTTPS Agent instance](https://nodejs.org/dist/latest/docs/api/https.html#https_class_https_agent) which will be used in the `https.request` method. If the `proxy` options defined, `agent` will be ignored!
 
 ### Returns
 

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -110,6 +110,7 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
     let extraHeaders = {};
     let contentEncoding = webPushConstants.supportedContentEncodings.AES_128_GCM;
     let proxy;
+    let agent;
 
     if (options) {
       const validOptionKeys = [
@@ -118,7 +119,8 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
         'vapidDetails',
         'TTL',
         'contentEncoding',
-        'proxy'
+        'proxy',
+        'agent'
       ];
       const optionKeys = Object.keys(options);
       for (let i = 0; i < optionKeys.length; i += 1) {
@@ -172,6 +174,14 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
           proxy = options.proxy;
         } else {
           console.warn('Attempt to use proxy option, but invalid type it should be a string or proxy options object.');
+        }
+      }
+
+      if (options.agent) {
+        if (options.agent instanceof https.Agent) {
+          agent = options.agent;
+        } else {
+          console.warn('Attempt to use agent option, but invalid type it should be an instanceof https.Agent.');
         }
       }
     }
@@ -265,6 +275,10 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
       requestDetails.proxy = proxy;
     }
 
+    if (agent) {
+      requestDetails.agent = agent;
+    }
+
     return requestDetails;
   };
 
@@ -299,6 +313,10 @@ WebPushLib.prototype.sendNotification = function(subscription, payload, options)
 
       httpsOptions.headers = requestDetails.headers;
       httpsOptions.method = requestDetails.method;
+
+      if (requestDetails.agent) {
+        httpsOptions.agent = requestDetails.agent;
+      }
 
       if (requestDetails.proxy) {
         httpsOptions.agent = new HttpsProxyAgent(requestDetails.proxy);

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -179,6 +179,10 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
 
       if (options.agent) {
         if (options.agent instanceof https.Agent) {
+          if (proxy) {
+            console.warn('Agent option will be ignored because proxy option is defined.');
+          }
+
           agent = options.agent;
         } else {
           console.warn('Wrong type for the agent option, it should be an instance of https.Agent.');

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -181,7 +181,7 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
         if (options.agent instanceof https.Agent) {
           agent = options.agent;
         } else {
-          console.warn('Attempt to use agent option, but invalid type it should be an instanceof https.Agent.');
+          console.warn('Wrong type for the agent option, it should be an instance of https.Agent.');
         }
       }
     }

--- a/test/test-generate-request-details.js
+++ b/test/test-generate-request-details.js
@@ -214,6 +214,19 @@ suite('Test Generate Request Details', function() {
           agent: 'agent'
         }
       }
+    }, {
+      testTitle: 'ignore valid agent if proxy denifed',
+      requestOptions: {
+        subscription: {
+          keys: VALID_KEYS
+        },
+        message: 'hello',
+        addEndpoint: true,
+        extraOptions: {
+          agent: new https.Agent({ keepAlive: true }),
+          proxy: 'http://localhost:3000'
+        }
+      }
     }
   ];
 

--- a/test/test-generate-request-details.js
+++ b/test/test-generate-request-details.js
@@ -6,6 +6,7 @@ const webPush = require('../src/index');
 const crypto = require('crypto');
 const jws = require('jws');
 const urlParse = require('url').parse;
+const https = require('https');
 
 suite('Test Generate Request Details', function() {
   test('is defined', function() {
@@ -201,6 +202,18 @@ suite('Test Generate Request Details', function() {
           }
         }
       }
+    }, {
+      testTitle: 'invalid agent',
+      requestOptions: {
+        subscription: {
+          keys: VALID_KEYS
+        },
+        message: 'hello',
+        addEndpoint: true,
+        extraOptions: {
+          agent: 'agent'
+        }
+      }
     }
   ];
 
@@ -328,5 +341,20 @@ suite('Test Generate Request Details', function() {
       extraOptions
     );
     assert.equal(details.proxy, extraOptions.proxy);
+  });
+
+  test('Agent option as an https.Agent instance', function() {
+    let subscription = {
+      endpoint: 'https://127.0.0.1:8080'
+    };
+    let extraOptions = {
+      agent: new https.Agent({ keepAlive: true })
+    };
+    let details = webPush.generateRequestDetails(
+      subscription,
+      null,
+      extraOptions
+    );
+    assert.equal(details.agent, extraOptions.agent);
   });
 });


### PR DESCRIPTION
Hello!

I'am using web-push to send a lot of push-notifications. We have got more than 3000rps.
To make sender service faster, i'am now doing something like this:
```
webPush.setVapidDetails(
    'mailto:help@test.com',
    config.vapid_public_key,
    config.vapid_private_key
);

https.globalAgent = new https.Agent({
    keepAlive: true,
    keepAliveMsecs: 100,
    ...
});
```
But it is not convenient to rewrite global agent.

Cause of this reason i have added `agent` options to specify a `https.Agent` instance