### PR TITLE
Require https-proxy-agent only when actually needed

### DIFF
--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -325,7 +325,7 @@ WebPushLib.prototype.sendNotification = function(subscription, payload, options)
       }
 
       if (requestDetails.proxy) {
-        const HttpsProxyAgent = require('https-proxy-agent');
+        const HttpsProxyAgent = require('https-proxy-agent'); // eslint-disable-line global-require
         httpsOptions.agent = new HttpsProxyAgent(requestDetails.proxy);
       }
 

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -3,7 +3,6 @@
 const urlBase64 = require('urlsafe-base64');
 const url = require('url');
 const https = require('https');
-const HttpsProxyAgent = require('https-proxy-agent');
 
 const WebPushError = require('./web-push-error.js');
 const vapidHelper = require('./vapid-helper.js');
@@ -326,6 +325,7 @@ WebPushLib.prototype.sendNotification = function(subscription, payload, options)
       }
 
       if (requestDetails.proxy) {
+        const HttpsProxyAgent = require('https-proxy-agent');
         httpsOptions.agent = new HttpsProxyAgent(requestDetails.proxy);
       }
 


### PR DESCRIPTION
`https-proxy-agent` patches core Node methods in `https` for whatever reason, and that breaks unrelated code. In our app we don't use proxy, and the mere fact that `web-push` requires the proxy package, it breaks other code.

See https://github.com/TooTallNate/node-agent-base/issues/35 and https://github.com/sindresorhus/got/issues/951