### PR TITLE
Fix issue #532, pad keys with leading zeroes instead of trailing zeroes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2077,6 +2077,7 @@
         "once": "1.x",
         "resolve": "1.1.x",
         "supports-color": "^3.1.0",
+        "which": "^1.1.1",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
@@ -2118,6 +2119,15 @@
           "dev": true,
           "requires": {
             "has-flag": "^1.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -2331,7 +2341,23 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
     },
     "lolex": {
       "version": "4.2.0",
@@ -3158,6 +3184,7 @@
       "requires": {
         "adm-zip": "~0.4.3",
         "async": "^2.1.2",
+        "https-proxy-agent": "^2.2.1",
         "lodash": "^4.16.6",
         "rimraf": "^2.5.4"
       },
@@ -3169,6 +3196,16 @@
           "dev": true,
           "requires": {
             "lodash": "^4.17.10"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
           }
         }
       }
@@ -3185,6 +3222,7 @@
       "integrity": "sha512-morRewKNTbQ7wbDtXSb3a78OJ++lHXJFv7CY18v2HDjC2mXf/96WavCNJEAkVItVGEyPul/x8hIiLhAad5nZBQ==",
       "dev": true,
       "requires": {
+        "chalk": "^2.1.0",
         "dmg": "^0.1.0",
         "fs-extra": "^5.0.0",
         "mkdirp": "^0.5.1",
@@ -3193,9 +3231,21 @@
         "sauce-connect-launcher": "^1.2.2",
         "selenium-webdriver": "3.6.0",
         "semver": "^5.4.1",
+        "which": "^1.3.0",
         "yauzl": "^2.8.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "fd-slicer": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -3210,6 +3260,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
           "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         },
         "yauzl": {
           "version": "2.10.0",

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -50,13 +50,13 @@ function generateVAPIDKeys() {
   if (privateKeyBuffer.length < 32) {
     const padding = Buffer.alloc(32 - privateKeyBuffer.length);
     padding.fill(0);
-    privateKeyBuffer = Buffer.concat([privateKeyBuffer, padding]);
+    privateKeyBuffer = Buffer.concat([padding, privateKeyBuffer]);
   }
 
   if (publicKeyBuffer.length < 65) {
     const padding = Buffer.alloc(65 - publicKeyBuffer.length);
     padding.fill(0);
-    publicKeyBuffer = Buffer.concat([publicKeyBuffer, padding]);
+    publicKeyBuffer = Buffer.concat([padding, publicKeyBuffer]);
   }
 
   return {


### PR DESCRIPTION
Trailing zeroes lead to invalid JWT tokens in FCM and invalid authorization in Mozilla Push, leading zeroes are skipped and succeed