### PR TITLE
skip redundant code code, correct readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ request only. This overrides any API key set via `setGCMAPIKey()`.
 - **TTL** is a value in seconds that describes how long a push message is
 retained by the push service (by default, four weeks).
 - **headers** is an object with all the extra headers you want to add to the request.
-- **contentEncoding** is the type of push encoding to use (e.g. 'aesgcm128gcm', by default, or 'aesgcm').
+- **contentEncoding** is the type of push encoding to use (e.g. 'aes128gcm', by default, or 'aesgcm').
 - **proxy** is the [HttpsProxyAgent's constructor argument](https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-options)
 that may either be a string URI of the proxy server (eg. http://< hostname >:< port >)
 or an "options" object with more specific properties.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ request only. This overrides any API key set via `setGCMAPIKey()`.
 - **TTL** is a value in seconds that describes how long a push message is
 retained by the push service (by default, four weeks).
 - **headers** is an object with all the extra headers you want to add to the request.
-- **contentEncoding** is the type of push encoding to use (e.g. 'aesgcm', by default, or 'aes128gcm').
+- **contentEncoding** is the type of push encoding to use (e.g. 'aesgcm128gcm', by default, or 'aesgcm').
 - **proxy** is the [HttpsProxyAgent's constructor argument](https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-options)
 that may either be a string URI of the proxy server (eg. http://< hostname >:< port >)
 or an "options" object with more specific properties.

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -115,7 +115,6 @@ function validatePrivateKey(privateKey) {
   if (privateKey.length !== 32) {
     throw new Error('Vapid private key should be 32 bytes long when decoded.');
   }
-  return privateKey;
 }
 
 /**
@@ -186,7 +185,9 @@ function getVapidHeaders(audience, subject, publicKey, privateKey, contentEncodi
 
   validateSubject(subject);
   validatePublicKey(publicKey);
-  privateKey = validatePrivateKey(privateKey);
+  validatePrivateKey(privateKey);
+
+  privateKey = urlBase64.decode(privateKey);
 
   if (expiration) {
     validateExpiration(expiration);

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -115,6 +115,7 @@ function validatePrivateKey(privateKey) {
   if (privateKey.length !== 32) {
     throw new Error('Vapid private key should be 32 bytes long when decoded.');
   }
+  return privateKey;
 }
 
 /**
@@ -185,10 +186,7 @@ function getVapidHeaders(audience, subject, publicKey, privateKey, contentEncodi
 
   validateSubject(subject);
   validatePublicKey(publicKey);
-  validatePrivateKey(privateKey);
-
-  publicKey = urlBase64.decode(publicKey);
-  privateKey = urlBase64.decode(privateKey);
+  privateKey = validatePrivateKey(privateKey);
 
   if (expiration) {
     validateExpiration(expiration);
@@ -215,13 +213,13 @@ function getVapidHeaders(audience, subject, publicKey, privateKey, contentEncodi
 
   if (contentEncoding === WebPushConstants.supportedContentEncodings.AES_128_GCM) {
     return {
-      Authorization: 'vapid t=' + jwt + ', k=' + urlBase64.encode(publicKey)
+      Authorization: 'vapid t=' + jwt + ', k=' + publicKey
     };
   }
   if (contentEncoding === WebPushConstants.supportedContentEncodings.AES_GCM) {
     return {
       Authorization: 'WebPush ' + jwt,
-      'Crypto-Key': 'p256ecdsa=' + urlBase64.encode(publicKey)
+      'Crypto-Key': 'p256ecdsa=' + publicKey
     };
   }
 

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -268,8 +268,6 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
           requestDetails.headers['Crypto-Key'] = vapidHeaders['Crypto-Key'];
         }
       }
-    } else if (isFCM && currentGCMAPIKey) {
-      requestDetails.headers.Authorization = 'key=' + currentGCMAPIKey;
     }
 
     requestDetails.body = requestPayload;

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -268,6 +268,8 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
           requestDetails.headers['Crypto-Key'] = vapidHeaders['Crypto-Key'];
         }
       }
+    } else if (isFCM && currentGCMAPIKey) {
+      requestDetails.headers.Authorization = 'key=' + currentGCMAPIKey;
     }
 
     requestDetails.body = requestPayload;


### PR DESCRIPTION
There's some areas in code which are redundant. Plus readme indicates that `aesgcm` is the default but in fact it's `aes128gcm`.