### PR TITLE
Add support for Urgency and Topic optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ request only. This overrides any API key set via `setGCMAPIKey()`.
 retained by the push service (by default, four weeks).
 - **headers** is an object with all the extra headers you want to add to the request.
 - **contentEncoding** is the type of push encoding to use (e.g. 'aesgcm', by default, or 'aes128gcm').
-- **urgency** is to indicate to the push service whether to send the notification immediately or prioritize the recipient’s device power considerations for delivery, provide one of the following values: very-low, low, normal, or high. To attempt to deliver the notification immediately, specify high.
+- **urgency** is to indicate to the push service whether to send the notification immediately or prioritize the recipient’s device power considerations for delivery. Provide one of the following values: very-low, low, normal, or high. To attempt to deliver the notification immediately, specify high.
 - **topic** optionally provide an identifier that the push service uses to coalesce notifications. Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets.
 - **proxy** is the [HttpsProxyAgent's constructor argument](https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-options)
 that may either be a string URI of the proxy server (eg. http://< hostname >:< port >)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ request only. This overrides any API key set via `setGCMAPIKey()`.
 retained by the push service (by default, four weeks).
 - **headers** is an object with all the extra headers you want to add to the request.
 - **contentEncoding** is the type of push encoding to use (e.g. 'aes128gcm', by default, or 'aesgcm').
-- **urgency** is to indicate to the push service whether to send the notification immediately or prioritize the recipient’s device power considerations for delivery, provide one of the following values: very-low, low, normal, or high. To attempt to deliver the notification immediately, specify high.
+- **urgency** is to indicate to the push service whether to send the notification immediately or prioritize the recipient’s device power considerations for delivery. Provide one of the following values: very-low, low, normal, or high. To attempt to deliver the notification immediately, specify high.
 - **topic** optionally provide an identifier that the push service uses to coalesce notifications. Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets.
 - **proxy** is the [HttpsProxyAgent's constructor argument](https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-options)
 that may either be a string URI of the proxy server (eg. http://< hostname >:< port >)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ const options = {
     '< header name >': '< header value >'
   },
   contentEncoding: '< Encoding type, e.g.: aesgcm or aes128gcm >',
+  urgency:'Defult is normal',
+  topic:'Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets.',
+
   proxy: '< proxy server options >',
   agent: '< https.Agent instance >'
 }
@@ -183,6 +186,8 @@ request only. This overrides any API key set via `setGCMAPIKey()`.
 retained by the push service (by default, four weeks).
 - **headers** is an object with all the extra headers you want to add to the request.
 - **contentEncoding** is the type of push encoding to use (e.g. 'aes128gcm', by default, or 'aesgcm').
+- **urgency** is to indicate to the push service whether to send the notification immediately or prioritize the recipient’s device power considerations for delivery, provide one of the following values: very-low, low, normal, or high. To attempt to deliver the notification immediately, specify high.
+- **topic** optionally provide an identifier that the push service uses to coalesce notifications. Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets.
 - **proxy** is the [HttpsProxyAgent's constructor argument](https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-options)
 that may either be a string URI of the proxy server (eg. http://< hostname >:< port >)
 or an "options" object with more specific properties.
@@ -357,6 +362,8 @@ const options = {
     '< header name >': '< header value >'
   },
   contentEncoding: '< Encoding type, e.g.: aesgcm or aes128gcm >',
+  urgency:''Defult is normal'',
+  topic:'Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets.',
   proxy: '< proxy server options >'
 }
 
@@ -411,6 +418,8 @@ request only. This overrides any API key set via `setGCMAPIKey()`.
 retained by the push service (by default, four weeks).
 - **headers** is an object with all the extra headers you want to add to the request.
 - **contentEncoding** is the type of push encoding to use (e.g. 'aesgcm', by default, or 'aes128gcm').
+- **urgency** is to indicate to the push service whether to send the notification immediately or prioritize the recipient’s device power considerations for delivery, provide one of the following values: very-low, low, normal, or high. To attempt to deliver the notification immediately, specify high.
+- **topic** optionally provide an identifier that the push service uses to coalesce notifications. Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets.
 - **proxy** is the [HttpsProxyAgent's constructor argument](https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-options)
 that may either be a string URI of the proxy server (eg. http://< hostname >:< port >)
 or an "options" object with more specific properties.
@@ -509,13 +518,13 @@ object will contain:
 <td>Safari</td>
 
 <!-- Push without payloads support-->
-<td>✗</td>
+<td>Safari 16 in macOS 13 or later</td>
 
 <!-- Push with payload support -->
-<td>✗</td>
+<td>Safari 16 in macOS 13 or later</td>
 
 <!-- VAPID Support -->
-<td>✗</td>
+<td>Safari 16 in macOS 13 or later</td>
 
 <td></td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ const options = {
     '< header name >': '< header value >'
   },
   contentEncoding: '< Encoding type, e.g.: aesgcm or aes128gcm >',
-  urgency:'< Defult is normal "Defult" >',
+  urgency:'< Default is normal "Defult" >',
   topic:'< Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets. >',
   proxy: '< proxy server options >'
 }

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ const options = {
     '< header name >': '< header value >'
   },
   contentEncoding: '< Encoding type, e.g.: aesgcm or aes128gcm >',
-  urgency:'Defult is normal',
-  topic:'Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets.',
+  urgency:'< Defult is "normal" >',
+  topic:'< Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets. >',
 
   proxy: '< proxy server options >',
   agent: '< https.Agent instance >'
@@ -362,8 +362,8 @@ const options = {
     '< header name >': '< header value >'
   },
   contentEncoding: '< Encoding type, e.g.: aesgcm or aes128gcm >',
-  urgency:''Defult is normal'',
-  topic:'Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets.',
+  urgency:'< Defult is normal "Defult" >',
+  topic:'< Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets. >',
   proxy: '< proxy server options >'
 }
 
@@ -518,15 +518,15 @@ object will contain:
 <td>Safari</td>
 
 <!-- Push without payloads support-->
-<td>Safari 16 in macOS 13 or later</td>
+<td>✓ v16+ </td>
 
 <!-- Push with payload support -->
-<td>Safari 16 in macOS 13 or later</td>
+<td>✓ v16+</td>
 
 <!-- VAPID Support -->
-<td>Safari 16 in macOS 13 or later</td>
+<td>✓ v16+</td>
 
-<td></td>
+<td>Safari 16 in macOS 13 or later</td>
 </tr>
 
 <tr>

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ const options = {
     '< header name >': '< header value >'
   },
   contentEncoding: '< Encoding type, e.g.: aesgcm or aes128gcm >',
-  urgency:'< Defult is "normal" >',
+  urgency:'< Default is "normal" >',
   topic:'< Use a maximum of 32 characters from the URL or filename-safe Base64 characters sets. >',
 
   proxy: '< proxy server options >',

--- a/src/web-push-constants.js
+++ b/src/web-push-constants.js
@@ -7,4 +7,11 @@ WebPushConstants.supportedContentEncodings = {
   AES_128_GCM: 'aes128gcm'
 };
 
+WebPushConstants.supportedUrgency = {
+  VERY_LOW:'very-low',
+  LOW:'low',
+  NORMAL:'normal',
+  HIGH:'high'
+};
+
 module.exports = WebPushConstants;

--- a/src/web-push-constants.js
+++ b/src/web-push-constants.js
@@ -8,10 +8,10 @@ WebPushConstants.supportedContentEncodings = {
 };
 
 WebPushConstants.supportedUrgency = {
-  VERY_LOW:'very-low',
-  LOW:'low',
-  NORMAL:'normal',
-  HIGH:'high'
+  VERY_LOW: 'very-low',
+  LOW: 'low',
+  NORMAL: 'normal',
+  HIGH: 'high'
 };
 
 module.exports = WebPushConstants;

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -109,8 +109,8 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
     let timeToLive = DEFAULT_TTL;
     let extraHeaders = {};
     let contentEncoding = webPushConstants.supportedContentEncodings.AES_128_GCM;
-    let urgency =webPushConstants.supportedUrgency.NORMAL;  
-    let topic; 
+    let urgency = webPushConstants.supportedUrgency.NORMAL;
+    let topic;
     let proxy;
     let agent;
     let timeout;
@@ -189,13 +189,13 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
       }
 
       if (options.Topic) {
-        if(!urlBase64.validate(options.topic)) {
-          throw new Error('Unsupported characters set use maximum of 32 characters from the URL or filename-safe Base64 characters set');
+        if (!urlBase64.validate(options.topic)) {
+          throw new Error('Unsupported characters set use the URL or filename-safe Base64 characters set');
         }
-        if(options.topic.length>32) {
+        if (options.topic.length > 32) {
           throw new Error('use maximum of 32 characters from the URL or filename-safe Base64 characters set');
         }
-        topic = options.Topic
+        topic = options.Topic;
       }
 
       if (options.proxy) {
@@ -297,10 +297,10 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
       requestDetails.headers.Authorization = 'key=' + currentGCMAPIKey;
     }
 
-    requestDetails.headers['Urgency'] = urgency
-    
-    if(topic){
-      requestDetails.headers['Topic'] = topic
+    requestDetails.headers['Urgency'] = urgency;
+
+    if (topic) {
+      requestDetails.headers['Topic'] = topic;
     }
 
     requestDetails.body = requestPayload;

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -297,10 +297,10 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
       requestDetails.headers.Authorization = 'key=' + currentGCMAPIKey;
     }
 
-    requestDetails.headers['Urgency'] = urgency;
+    requestDetails.headers.Urgency = urgency;
 
     if (topic) {
-      requestDetails.headers['Topic'] = topic;
+      requestDetails.headers.Topic = topic;
     }
 
     requestDetails.body = requestPayload;

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -109,6 +109,8 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
     let timeToLive = DEFAULT_TTL;
     let extraHeaders = {};
     let contentEncoding = webPushConstants.supportedContentEncodings.AES_128_GCM;
+    let urgency =webPushConstants.supportedUrgency.NORMAL;  
+    let topic; 
     let proxy;
     let agent;
     let timeout;
@@ -120,6 +122,8 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
         'vapidDetails',
         'TTL',
         'contentEncoding',
+        'urgency',
+        'topic',
         'proxy',
         'agent',
         'timeout'
@@ -171,6 +175,27 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
         } else {
           throw new Error('Unsupported content encoding specified.');
         }
+      }
+
+      if (options.urgency) {
+        if ((options.urgency === webPushConstants.supportedUrgency.VERY_LOW
+          || options.urgency === webPushConstants.supportedUrgency.LOW
+          || options.urgency === webPushConstants.supportedUrgency.NORMAL
+          || options.urgency === webPushConstants.supportedUrgency.HIGH)) {
+          urgency = options.urgency;
+        } else {
+          throw new Error('Unsupported urgency specified.');
+        }
+      }
+
+      if (options.Topic) {
+        if(!urlBase64.validate(options.topic)) {
+          throw new Error('Unsupported characters set use maximum of 32 characters from the URL or filename-safe Base64 characters set');
+        }
+        if(options.topic.length>32) {
+          throw new Error('use maximum of 32 characters from the URL or filename-safe Base64 characters set');
+        }
+        topic = options.Topic
       }
 
       if (options.proxy) {
@@ -270,6 +295,12 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
       }
     } else if (isFCM && currentGCMAPIKey) {
       requestDetails.headers.Authorization = 'key=' + currentGCMAPIKey;
+    }
+
+    requestDetails.headers['Urgency'] = urgency
+    
+    if(topic){
+      requestDetails.headers['Topic'] = topic
     }
 
     requestDetails.body = requestPayload;

--- a/test/test-generate-request-details.js
+++ b/test/test-generate-request-details.js
@@ -258,7 +258,7 @@ suite('Test Generate Request Details', function() {
       TTL: 100,
       headers: {
         'Topic': 'topic',
-        'Urgency': 'urgency'
+        'Urgency': 'normal'
       }
     };
     let details = webPush.generateRequestDetails(


### PR DESCRIPTION
## What is this PR for?

Adding support for web push notifications for Safari 16.

## What does this PR include?

- Web push notifications support including topic and urgency headers.
- Updated readme file.

I'm working on a project that implements web push notifications using the web-push npm package. I've realized that Safari support didn't make it to the package yet, so I made this PR to add support for Safari. I was hesitant to open a PR before having a discussion with the community/team, but I think the modifications are simple enough to have that discussion on the PR. This is my first OSS PR, would love some feedback.