### PR TITLE
Fix options from 'Topic' to 'topic'

### DIFF
--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -188,14 +188,14 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
         }
       }
 
-      if (options.Topic) {
+      if (options.topic) {
         if (!urlBase64.validate(options.topic)) {
           throw new Error('Unsupported characters set use the URL or filename-safe Base64 characters set');
         }
         if (options.topic.length > 32) {
           throw new Error('use maximum of 32 characters from the URL or filename-safe Base64 characters set');
         }
-        topic = options.Topic;
+        topic = options.topic;
       }
 
       if (options.proxy) {


### PR DESCRIPTION
Support for the 'Topic' optional parameter was introduced in PR #764 but it is not functioning due to incorrect capitalization.

As a newcomer to open-source contributions, I apologize if my approach seems impolite. Thank you.