### PR TITLE
fix(sendnotification): fix HttpsProxyAgent error

### DIFF
--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -362,7 +362,7 @@ WebPushLib.prototype.sendNotification = function(subscription, payload, options)
       }
 
       if (requestDetails.proxy) {
-        const HttpsProxyAgent = require('https-proxy-agent'); // eslint-disable-line global-require
+        const { HttpsProxyAgent } = require('https-proxy-agent'); // eslint-disable-line global-require
         httpsOptions.agent = new HttpsProxyAgent(requestDetails.proxy);
       }
 

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -327,6 +327,16 @@ suite('sendNotification', function() {
         }
       }
     }, {
+      testTitle: 'send/receive with proxy',
+      requestOptions: {
+        subscription: {
+          // The default endpoint will be added by the test
+        },
+        extraOptions: {
+          proxy: 'http://127.0.0.1:7890'
+        }
+      }
+    }, {
       testTitle: 'server returns 201',
       requestOptions: {
         subscription: {

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -327,16 +327,6 @@ suite('sendNotification', function() {
         }
       }
     }, {
-      testTitle: 'send/receive with proxy',
-      requestOptions: {
-        subscription: {
-          // The default endpoint will be added by the test
-        },
-        extraOptions: {
-          proxy: 'http://127.0.0.1:7890'
-        }
-      }
-    }, {
       testTitle: 'server returns 201',
       requestOptions: {
         subscription: {


### PR DESCRIPTION
https-proxy-agent 7.x changed the default export
https://github.com/TooTallNate/proxy-agents/blob/main/packages/https-proxy-agent/README.md#https-module-example 