### PR TITLE
Fixes sendNotification named import declaration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,5 +17,5 @@ module.exports = {
   setGCMAPIKey: webPush.setGCMAPIKey,
   setVapidDetails: webPush.setVapidDetails,
   generateRequestDetails: webPush.generateRequestDetails,
-  sendNotification: webPush.sendNotification
+  sendNotification: webPush.sendNotification.bind(webPush)
 };

--- a/test/test-generate-request-details.js
+++ b/test/test-generate-request-details.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const webPush = require('../src/index');
+const { generateRequestDetails } = require('../src/index');
 const crypto = require('crypto');
 const jws = require('jws');
 const urlParse = require('url').parse;
@@ -9,7 +9,7 @@ const https = require('https');
 
 suite('Test Generate Request Details', function() {
   test('is defined', function() {
-    assert(webPush.generateRequestDetails);
+    assert(generateRequestDetails);
   });
 
   const userCurve = crypto.createECDH('prime256v1');
@@ -241,7 +241,7 @@ suite('Test Generate Request Details', function() {
       }
 
       assert.throws(function() {
-        return webPush.generateRequestDetails(
+        return generateRequestDetails(
           invalidRequest.requestOptions.subscription,
           invalidRequest.requestOptions.message,
           invalidRequest.requestOptions.extraOptions
@@ -260,7 +260,7 @@ suite('Test Generate Request Details', function() {
         'Urgency': 'normal'
       }
     };
-    let details = webPush.generateRequestDetails(
+    let details = generateRequestDetails(
       subscription,
       message,
       extraOptions
@@ -283,7 +283,7 @@ suite('Test Generate Request Details', function() {
       }
     };
 
-    const requestDetails = webPush.generateRequestDetails(subscription, null, extraOptions);
+    const requestDetails = generateRequestDetails(subscription, null, extraOptions);
     const authHeader = requestDetails.headers.Authorization;
 
     // Get the Encoded JWT Token from the Authorization Header
@@ -311,7 +311,7 @@ suite('Test Generate Request Details', function() {
       contentEncoding: 'aesgcm'
     };
 
-    const requestDetails = webPush.generateRequestDetails(subscription, null, extraOptions);
+    const requestDetails = generateRequestDetails(subscription, null, extraOptions);
     const authHeader = requestDetails.headers.Authorization;
 
     // Get the Encoded JWT Token from the Authorization Header
@@ -331,7 +331,7 @@ suite('Test Generate Request Details', function() {
     let extraOptions = {
       'proxy': 'proxy'
     };
-    let details = webPush.generateRequestDetails(
+    let details = generateRequestDetails(
       subscription,
       message,
       extraOptions
@@ -347,7 +347,7 @@ suite('Test Generate Request Details', function() {
     let extraOptions = {
       proxy: proxyOption
     };
-    let details = webPush.generateRequestDetails(
+    let details = generateRequestDetails(
       subscription,
       null,
       extraOptions
@@ -362,7 +362,7 @@ suite('Test Generate Request Details', function() {
     let extraOptions = {
       agent: new https.Agent({ keepAlive: true })
     };
-    let details = webPush.generateRequestDetails(
+    let details = generateRequestDetails(
       subscription,
       null,
       extraOptions

--- a/test/test-set-vapid-details.js
+++ b/test/test-set-vapid-details.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const webPush = require('../src/index');
+const { setVapidDetails } = require('../src/index');
 
 const VALID_SUBJECT_MAILTO = 'mailto: example@example.com';
 const VALID_SUBJECT_URL = 'https://exampe.com/contact';
@@ -10,24 +10,24 @@ const VALID_PRIVATE_KEY = Buffer.alloc(32).toString('base64url');
 
 suite('setVapidDetails()', function() {
   test('is defined', function() {
-    assert(webPush.setVapidDetails);
+    assert(setVapidDetails);
   });
 
   test('Valid URL input', function() {
     assert.doesNotThrow(function() {
-      webPush.setVapidDetails(VALID_SUBJECT_URL, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY);
+      setVapidDetails(VALID_SUBJECT_URL, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY);
     });
   });
 
   test('Valid mailto: input', function() {
     assert.doesNotThrow(function() {
-      webPush.setVapidDetails(VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY);
+      setVapidDetails(VALID_SUBJECT_MAILTO, VALID_PUBLIC_KEY, VALID_PRIVATE_KEY);
     });
   });
 
   test('reset Vapid Details with null', function() {
     assert.doesNotThrow(function() {
-      webPush.setVapidDetails(null);
+      setVapidDetails(null);
     });
   });
 
@@ -107,7 +107,7 @@ suite('setVapidDetails()', function() {
   test('Invalid input should throw an error', function() {
     invalidInputs.forEach(function(invalidInput, index) {
       assert.throws(function() {
-        webPush.setVapidDetails(
+        setVapidDetails(
           invalidInput.subject,
           invalidInput.publicKey,
           invalidInput.privateKey

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -12,14 +12,16 @@ const mocha = require('mocha');
 const WebPushConstants = require('../src/web-push-constants.js');
 
 suite('sendNotification', function() {
-  let webPush;
+  let sendNotification;
+  let setGCMAPIKey;
+  let setVapidDetails;
 
   mocha.beforeEach(function () {
-    webPush = require('../src/index');
+    ({ sendNotification, setGCMAPIKey, setVapidDetails } = require('../src/index'));
   });
 
   test('is defined', function() {
-    assert(webPush.sendNotification);
+    assert(sendNotification);
   });
 
   let server;
@@ -369,7 +371,7 @@ suite('sendNotification', function() {
       validRequest.requestOptions.extraOptions = validRequest.requestOptions.extraOptions || {};
       validRequest.requestOptions.extraOptions.contentEncoding = WebPushConstants.supportedContentEncodings.AES_GCM;
 
-      return webPush.sendNotification(
+      return sendNotification(
         validRequest.requestOptions.subscription,
         validRequest.requestOptions.message,
         validRequest.requestOptions.extraOptions
@@ -396,7 +398,7 @@ suite('sendNotification', function() {
       validRequest.requestOptions.extraOptions = validRequest.requestOptions.extraOptions || {};
       validRequest.requestOptions.extraOptions.contentEncoding = WebPushConstants.supportedContentEncodings.AES_128_GCM;
 
-      return webPush.sendNotification(
+      return sendNotification(
         validRequest.requestOptions.subscription,
         validRequest.requestOptions.message,
         validRequest.requestOptions.extraOptions
@@ -586,17 +588,17 @@ suite('sendNotification', function() {
       }
 
       if (validGCMRequest.globalOptions.gcmAPIKey) {
-        webPush.setGCMAPIKey(validGCMRequest.globalOptions.gcmAPIKey);
+        setGCMAPIKey(validGCMRequest.globalOptions.gcmAPIKey);
       }
       if (validGCMRequest.globalOptions.vapidDetails) {
-        webPush.setVapidDetails(
+        setVapidDetails(
           validGCMRequest.globalOptions.vapidDetails.subject,
           validGCMRequest.globalOptions.vapidDetails.publicKey,
           validGCMRequest.globalOptions.vapidDetails.privateKey
         );
       }
 
-      return webPush.sendNotification(
+      return sendNotification(
         validGCMRequest.requestOptions.subscription,
         validGCMRequest.requestOptions.message,
         validGCMRequest.requestOptions.extraOptions
@@ -801,7 +803,7 @@ suite('sendNotification', function() {
       invalidRequest.requestOptions.extraOptions = invalidRequest.requestOptions.extraOptions || {};
       invalidRequest.requestOptions.extraOptions.contentEncoding = WebPushConstants.supportedContentEncodings.AES_GCM;
 
-      return webPush.sendNotification(
+      return sendNotification(
         invalidRequest.requestOptions.subscription,
         invalidRequest.requestOptions.message,
         invalidRequest.requestOptions.extraOptions
@@ -826,7 +828,7 @@ suite('sendNotification', function() {
       invalidRequest.requestOptions.extraOptions = invalidRequest.requestOptions.extraOptions || {};
       invalidRequest.requestOptions.extraOptions.contentEncoding = WebPushConstants.supportedContentEncodings.AES_128_GCM;
 
-      return webPush.sendNotification(
+      return sendNotification(
         invalidRequest.requestOptions.subscription,
         invalidRequest.requestOptions.message,
         invalidRequest.requestOptions.extraOptions
@@ -843,7 +845,7 @@ suite('sendNotification', function() {
     const currentServerPort = serverPort;
     return closeServer()
     .then(function() {
-      return webPush.sendNotification({
+      return sendNotification({
         endpoint: 'https://127.0.0.1:' + currentServerPort
       })
       .then(function() {

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -12,8 +12,13 @@ const mocha = require('mocha');
 const WebPushConstants = require('../src/web-push-constants.js');
 
 suite('sendNotification', function() {
+  let webPush;
+
+  mocha.beforeEach(function () {
+    webPush = require('../src/index');
+  });
+
   test('is defined', function() {
-    const webPush = require('../src/index');
     assert(webPush.sendNotification);
   });
 
@@ -364,7 +369,6 @@ suite('sendNotification', function() {
       validRequest.requestOptions.extraOptions = validRequest.requestOptions.extraOptions || {};
       validRequest.requestOptions.extraOptions.contentEncoding = WebPushConstants.supportedContentEncodings.AES_GCM;
 
-      const webPush = require('../src/index');
       return webPush.sendNotification(
         validRequest.requestOptions.subscription,
         validRequest.requestOptions.message,
@@ -392,7 +396,6 @@ suite('sendNotification', function() {
       validRequest.requestOptions.extraOptions = validRequest.requestOptions.extraOptions || {};
       validRequest.requestOptions.extraOptions.contentEncoding = WebPushConstants.supportedContentEncodings.AES_128_GCM;
 
-      const webPush = require('../src/index');
       return webPush.sendNotification(
         validRequest.requestOptions.subscription,
         validRequest.requestOptions.message,
@@ -582,7 +585,6 @@ suite('sendNotification', function() {
         validGCMRequest.globalOptions.gcmAPIKey = 'my_gcm_key';
       }
 
-      const webPush = require('../src/index');
       if (validGCMRequest.globalOptions.gcmAPIKey) {
         webPush.setGCMAPIKey(validGCMRequest.globalOptions.gcmAPIKey);
       }
@@ -799,7 +801,6 @@ suite('sendNotification', function() {
       invalidRequest.requestOptions.extraOptions = invalidRequest.requestOptions.extraOptions || {};
       invalidRequest.requestOptions.extraOptions.contentEncoding = WebPushConstants.supportedContentEncodings.AES_GCM;
 
-      const webPush = require('../src/index');
       return webPush.sendNotification(
         invalidRequest.requestOptions.subscription,
         invalidRequest.requestOptions.message,
@@ -825,7 +826,6 @@ suite('sendNotification', function() {
       invalidRequest.requestOptions.extraOptions = invalidRequest.requestOptions.extraOptions || {};
       invalidRequest.requestOptions.extraOptions.contentEncoding = WebPushConstants.supportedContentEncodings.AES_128_GCM;
 
-      const webPush = require('../src/index');
       return webPush.sendNotification(
         invalidRequest.requestOptions.subscription,
         invalidRequest.requestOptions.message,
@@ -843,7 +843,6 @@ suite('sendNotification', function() {
     const currentServerPort = serverPort;
     return closeServer()
     .then(function() {
-      const webPush = require('../src/index');
       return webPush.sendNotification({
         endpoint: 'https://127.0.0.1:' + currentServerPort
       })

--- a/test/testSetGCMAPIKey.js
+++ b/test/testSetGCMAPIKey.js
@@ -1,40 +1,40 @@
 'use strict';
 
 const assert = require('assert');
-const webPush = require('../src/index');
+const { setGCMAPIKey } = require('../src/index');
 
 suite('setGCMAPIKey', function() {
   test('is defined', function() {
-    assert(webPush.setGCMAPIKey);
+    assert(setGCMAPIKey);
   });
 
   test('non-empty string', function() {
     assert.doesNotThrow(function() {
-      webPush.setGCMAPIKey('AIzaSyAwmdX6KKd4hPfIcGU2SOfj9vuRDW6u-wo');
+      setGCMAPIKey('AIzaSyAwmdX6KKd4hPfIcGU2SOfj9vuRDW6u-wo');
     });
   });
 
   test('reset GCM API Key with null', function() {
     assert.doesNotThrow(function() {
-      webPush.setGCMAPIKey(null);
+      setGCMAPIKey(null);
     });
   });
 
   test('empty string', function() {
     assert.throws(function() {
-      webPush.setGCMAPIKey('');
+      setGCMAPIKey('');
     }, Error);
   });
 
   test('non string', function() {
     assert.throws(function() {
-      webPush.setGCMAPIKey(42);
+      setGCMAPIKey(42);
     }, Error);
   });
 
   test('undefined value', function() {
     assert.throws(function() {
-      webPush.setGCMAPIKey();
+      setGCMAPIKey();
     }, Error);
   });
 });


### PR DESCRIPTION
Fixes #683

I was able to reproduce the TypeScript issue seen in #683 within the existing test suite in 30c5932.  Previously, requiring `sendNotification` as a named import would fail [here](https://github.com/web-push-libs/web-push/blob/master/src/web-push-lib.js#L341) due to the function lacking reference to the prototype instance.  5277eea binds the prototype instance to the exported `sendNotification` function using [ES5 syntax](https://caniuse.com/es5).  The pattern of testing on named imports is extended to all other `WebPushLib` methods in 2548c3a to prevent the same issue from occurring on another method in the future.