### PR TITLE
Fix validation error of protocol not beeing returned

### DIFF
--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -75,8 +75,9 @@ function validateSubject(subject) {
     + 'mailto: address. ' + subject);
   }
 
+  let subjectParseResult = null;
   try {
-    const subjectParseResult = new URL(subject);
+    subjectParseResult = new URL(subject);
   } catch (err) {
     throw new Error('Vapid subject is not a valid URL. ' + subject);
   }

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -77,17 +77,17 @@ function validateSubject(subject) {
 
   try {
     const subjectParseResult = new URL(subject);
-    if (!['https:', 'mailto:'].includes(subjectParseResult.protocol)) {
-      throw new Error('Vapid subject is not an https: or mailto: URL. ' + subject);
-    }
-    if (subjectParseResult.hostname === 'localhost') {
-      console.warn('Vapid subject points to a localhost web URI, which is unsupported by '
-        + 'Apple\'s push notification server and will result in a BadJwtToken error when '
-        + 'sending notifications.');
     }
   } catch (err) {
-    throw new Error('Vapid subject is not a valid URL. ' + subject, { cause: err });
+    throw new Error('Vapid subject is not a valid URL. ' + subject);
   }
+  if (!['https:', 'mailto:'].includes(subjectParseResult.protocol)) {
+    throw new Error('Vapid subject is not an https: or mailto: URL. ' + subject);
+  }
+  if (subjectParseResult.hostname === 'localhost') {
+    console.warn('Vapid subject points to a localhost web URI, which is unsupported by '
+      + 'Apple\'s push notification server and will result in a BadJwtToken error when '
+      + 'sending notifications.');
 }
 
 function validatePublicKey(publicKey) {

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -77,7 +77,6 @@ function validateSubject(subject) {
 
   try {
     const subjectParseResult = new URL(subject);
-    }
   } catch (err) {
     throw new Error('Vapid subject is not a valid URL. ' + subject);
   }
@@ -88,6 +87,7 @@ function validateSubject(subject) {
     console.warn('Vapid subject points to a localhost web URI, which is unsupported by '
       + 'Apple\'s push notification server and will result in a BadJwtToken error when '
       + 'sending notifications.');
+    }
 }
 
 function validatePublicKey(publicKey) {

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -86,7 +86,7 @@ function validateSubject(subject) {
         + 'sending notifications.');
     }
   } catch (err) {
-    throw new Error('Vapid subject is not a valid URL. ' + subject);
+    throw new Error('Vapid subject is not a valid URL. ' + subject, { cause: err });
   }
 }
 


### PR DESCRIPTION
Fixes #830

Fix the "https: or mailto:" error being overwritten by the error in the catch by passing it upwards trough the cause property