### PR TITLE
adds .nyc_output/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage/
 node_modules/
 test/output/
+.nyc_output/


### PR DESCRIPTION
`npm test` generates a `.nyc_output` directory that shouldn't be committed to the repository. 