### PR TITLE
Remove link to serviceworke.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,13 +574,6 @@ object will contain:
 </tbody>
 </table>
 
-# Help
-
-**Service Worker Cookbook**
-
-The [Service Worker Cookbook](https://serviceworke.rs/) is full of Web Push
-examples using this library.
-
 # Running tests
 
 > Prerequisites:


### PR DESCRIPTION
According to https://github.com/mdn/serviceworker-cookbook/pull/335,  "The domain https://serviceworke.rs/ (do not open) has been overtaken and are used to steal clicks. This removes the domain and uses a dummy domain."