### PR TITLE
Support multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,32 @@ object will contain:
 
 <hr />
 
+# Using multiple instances of `WebPushLib`
+
+The functions `setGCMAPIKey`, `setVapidDetails`, `generateRequestDetails`, `sendNotification`
+exported by this module are bounded to a global instance of `WebPushLib`.
+
+In scenarios where multiple instances of `WebPushLib` is needed, you can create separate instances by:
+```js
+const { WebPushLib } = require('web-push');
+
+const webpush1 = new WebPushLib();
+webpush1.setGCMAPIKey('<Your GCM API Key Here>');
+webpush1.setVapidDetails(
+  'mailto:example@yourdomain.org',
+  vapidKeys1.publicKey,
+  vapidKeys1.privateKey
+);
+
+const webpush2 = new WebPushLib();
+webpush2.setGCMAPIKey('<Another GCM API Key Here>');
+webpush2.setVapidDetails(
+  'mailto:example2@yourdomain.org',
+  vapidKeys2.publicKey,
+  vapidKeys2.privateKey
+);
+```
+
 # Browser Support
 
 <table>

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,14 @@ const WebPushConstants = require('./web-push-constants.js');
 const webPush = new WebPushLib();
 
 module.exports = {
+  WebPushLib: WebPushLib,
   WebPushError: WebPushError,
   supportedContentEncodings: WebPushConstants.supportedContentEncodings,
   encrypt: encryptionHelper.encrypt,
   getVapidHeaders: vapidHelper.getVapidHeaders,
   generateVAPIDKeys: vapidHelper.generateVAPIDKeys,
-  setGCMAPIKey: webPush.setGCMAPIKey,
-  setVapidDetails: webPush.setVapidDetails,
-  generateRequestDetails: webPush.generateRequestDetails,
+  setGCMAPIKey: webPush.setGCMAPIKey.bind(webPush),
+  setVapidDetails: webPush.setVapidDetails.bind(webPush),
+  generateRequestDetails: webPush.generateRequestDetails.bind(webPush),
   sendNotification: webPush.sendNotification.bind(webPush)
 };

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -12,11 +12,12 @@ const urlBase64Helper = require('./urlsafe-base64-helper');
 // Default TTL is four weeks.
 const DEFAULT_TTL = 2419200;
 
-let gcmAPIKey = '';
-let vapidDetails;
-
+/**
+ * @constructor
+ */
 function WebPushLib() {
-
+  this.gcmAPIKey = '';
+  this.vapidDetails;
 }
 
 /**
@@ -27,7 +28,7 @@ function WebPushLib() {
  */
 WebPushLib.prototype.setGCMAPIKey = function(apiKey) {
   if (apiKey === null) {
-    gcmAPIKey = null;
+    this.gcmAPIKey = null;
     return;
   }
 
@@ -37,7 +38,7 @@ WebPushLib.prototype.setGCMAPIKey = function(apiKey) {
     throw new Error('The GCM API Key should be a non-empty string or null.');
   }
 
-  gcmAPIKey = apiKey;
+  this.gcmAPIKey = apiKey;
 };
 
 /**
@@ -52,7 +53,7 @@ WebPushLib.prototype.setGCMAPIKey = function(apiKey) {
  */
 WebPushLib.prototype.setVapidDetails = function(subject, publicKey, privateKey) {
     if (arguments.length === 1 && arguments[0] === null) {
-      vapidDetails = null;
+      this.vapidDetails = null;
       return;
     }
 
@@ -60,7 +61,7 @@ WebPushLib.prototype.setVapidDetails = function(subject, publicKey, privateKey) 
     vapidHelper.validatePublicKey(publicKey);
     vapidHelper.validatePrivateKey(privateKey);
 
-    vapidDetails = {
+    this.vapidDetails = {
       subject: subject,
       publicKey: publicKey,
       privateKey: privateKey
@@ -104,8 +105,8 @@ WebPushLib.prototype.generateRequestDetails = function(subscription, payload, op
       }
     }
 
-    let currentGCMAPIKey = gcmAPIKey;
-    let currentVapidDetails = vapidDetails;
+    let currentGCMAPIKey = this.gcmAPIKey;
+    let currentVapidDetails = this.vapidDetails;
     let timeToLive = DEFAULT_TTL;
     let extraHeaders = {};
     let contentEncoding = webPushConstants.supportedContentEncodings.AES_128_GCM;


### PR DESCRIPTION
## Goal
Resolves #876

## Implementation
- Instead of having a module-scoped `gcmAPIKey` and `vapidDetails` in `src/web-push-lib.js`, we change those to instance properties of a `WebPushLib` class instance.
- When re-exporting the `setGCMAPIKey`, `setVapidDetails`, `generateRequestDetails` for the global instance of `WebPushLib`, we need to `.bind()` the methods to retain the `this` context.
- Also export the `WebPushLib` constructor so users can create multiple instances instead of just using the global instance.

