### PR TITLE
feat: migrate package to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "web-push",
   "version": "3.6.7",
   "description": "Web Push library for Node.js",
+  "type": "module",
   "main": "src/index.js",
   "bin": {
     "web-push": "src/cli.js"

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,8 +1,8 @@
 #! /usr/bin/env node
 
-'use strict';
+import minimist from 'minimist';
 
-const webPush = require('../src/index.js');
+import * as webPush from '../src/index.js';
 
 const printUsageDetails = () => {
   const actions = [
@@ -112,7 +112,7 @@ const sendNotification = args => {
 };
 
 const action = process.argv[2];
-const argv = require('minimist')(process.argv.slice(3));
+const argv = minimist(process.argv.slice(3));
 switch (action) {
   case 'send-notification':
     if (!argv.endpoint) {

--- a/src/encryption-helper.js
+++ b/src/encryption-helper.js
@@ -1,9 +1,7 @@
-'use strict';
+import crypto from 'node:crypto';
+import ece from 'http_ece';
 
-const crypto = require('crypto');
-const ece = require('http_ece');
-
-const encrypt = function(userPublicKey, userAuth, payload, contentEncoding) {
+export function encrypt(userPublicKey, userAuth, payload, contentEncoding) {
   if (!userPublicKey) {
     throw new Error('No user public key provided for encryption.');
   }
@@ -55,8 +53,4 @@ const encrypt = function(userPublicKey, userAuth, payload, contentEncoding) {
     salt: salt,
     cipherText: cipherText
   };
-};
-
-module.exports = {
-  encrypt: encrypt
-};
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,13 @@
-'use strict';
+import { WebPushLib } from './web-push-lib.js';
 
-const vapidHelper = require('./vapid-helper.js');
-const encryptionHelper = require('./encryption-helper.js');
-const WebPushLib = require('./web-push-lib.js');
-const WebPushError = require('./web-push-error.js');
-const WebPushConstants = require('./web-push-constants.js');
+export { WebPushError } from './web-push-error.js';
+export { encrypt } from './encryption-helper.js';
+export { getVapidHeaders, generateVAPIDKeys } from './vapid-helper.js';
+export { supportedContentEncodings } from './web-push-constants.js';
 
 const webPush = new WebPushLib();
 
-module.exports = {
-  WebPushError: WebPushError,
-  supportedContentEncodings: WebPushConstants.supportedContentEncodings,
-  encrypt: encryptionHelper.encrypt,
-  getVapidHeaders: vapidHelper.getVapidHeaders,
-  generateVAPIDKeys: vapidHelper.generateVAPIDKeys,
-  setGCMAPIKey: webPush.setGCMAPIKey,
-  setVapidDetails: webPush.setVapidDetails,
-  generateRequestDetails: webPush.generateRequestDetails,
-  sendNotification: webPush.sendNotification.bind(webPush)
-};
+export const setGCMAPIKey = webPush.setGCMAPIKey;
+export const setVapidDetails = webPush.setVapidDetails;
+export const generateRequestDetails = webPush.generateRequestDetails;
+export const sendNotification = webPush.sendNotification.bind(webPush);

--- a/src/urlsafe-base64-helper.js
+++ b/src/urlsafe-base64-helper.js
@@ -1,13 +1,7 @@
-'use strict';
-
 /**
  * @param {string} base64
  * @returns {boolean}
  */
-function validate(base64) {
+export function validate(base64) {
   return /^[A-Za-z0-9\-_]+$/.test(base64);
 }
-
-module.exports = {
-  validate: validate
-};

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -1,12 +1,10 @@
-'use strict';
+import crypto from 'node:crypto';
+import { URL } from 'node:url';
+import asn1 from 'asn1.js';
+import jws from 'jws';
 
-const crypto = require('crypto');
-const asn1 = require('asn1.js');
-const jws = require('jws');
-const { URL } = require('url');
-
-const WebPushConstants = require('./web-push-constants.js');
-const urlBase64Helper = require('./urlsafe-base64-helper');
+import * as WebPushConstants from './web-push-constants.js';
+import * as urlBase64Helper from './urlsafe-base64-helper.js';
 
 /**
  * DEFAULT_EXPIRATION is set to seconds in 12 hours
@@ -37,7 +35,7 @@ function toPEM(key) {
   });
 }
 
-function generateVAPIDKeys() {
+export function generateVAPIDKeys() {
   const curve = crypto.createECDH('prime256v1');
   curve.generateKeys();
 
@@ -65,7 +63,7 @@ function generateVAPIDKeys() {
   };
 }
 
-function validateSubject(subject) {
+export function validateSubject(subject) {
   if (!subject) {
     throw new Error('No subject set in vapidDetails.subject.');
   }
@@ -96,7 +94,7 @@ function validateSubject(subject) {
     }
 }
 
-function validatePublicKey(publicKey) {
+export function validatePublicKey(publicKey) {
   if (!publicKey) {
     throw new Error('No key set vapidDetails.publicKey');
   }
@@ -117,7 +115,7 @@ function validatePublicKey(publicKey) {
   }
 }
 
-function validatePrivateKey(privateKey) {
+export function validatePrivateKey(privateKey) {
   if (!privateKey) {
     throw new Error('No key set in vapidDetails.privateKey');
   }
@@ -146,7 +144,7 @@ function validatePrivateKey(privateKey) {
  * @param {Number} numSeconds Number of seconds to be added
  * @return {Number} Future expiration in seconds
  */
-function getFutureExpirationTimestamp(numSeconds) {
+export function getFutureExpirationTimestamp(numSeconds) {
   const futureExp = new Date();
   futureExp.setSeconds(futureExp.getSeconds() + numSeconds);
   return Math.floor(futureExp.getTime() / 1000);
@@ -158,7 +156,7 @@ function getFutureExpirationTimestamp(numSeconds) {
  *
  * @param {Number} expiration Expiration seconds from Epoch to be validated
  */
-function validateExpiration(expiration) {
+export function validateExpiration(expiration) {
   if (!Number.isInteger(expiration)) {
     throw new Error('`expiration` value must be a number');
   }
@@ -189,7 +187,7 @@ function validateExpiration(expiration) {
  * @return {Object}                 Returns an Object with the Authorization and
  * 'Crypto-Key' values to be used as headers.
  */
-function getVapidHeaders(audience, subject, publicKey, privateKey, contentEncoding, expiration) {
+export function getVapidHeaders(audience, subject, publicKey, privateKey, contentEncoding, expiration) {
   if (!audience) {
     throw new Error('No audience could be generated for VAPID.');
   }
@@ -253,13 +251,3 @@ function getVapidHeaders(audience, subject, publicKey, privateKey, contentEncodi
 
   throw new Error('Unsupported encoding type specified.');
 }
-
-module.exports = {
-  generateVAPIDKeys: generateVAPIDKeys,
-  getFutureExpirationTimestamp: getFutureExpirationTimestamp,
-  getVapidHeaders: getVapidHeaders,
-  validateSubject: validateSubject,
-  validatePublicKey: validatePublicKey,
-  validatePrivateKey: validatePrivateKey,
-  validateExpiration: validateExpiration
-};

--- a/src/web-push-constants.js
+++ b/src/web-push-constants.js
@@ -1,17 +1,11 @@
-'use strict';
-
-const WebPushConstants = {};
-
-WebPushConstants.supportedContentEncodings = {
+export const supportedContentEncodings = {
   AES_GCM: 'aesgcm',
   AES_128_GCM: 'aes128gcm'
 };
 
-WebPushConstants.supportedUrgency = {
+export const supportedUrgency = {
   VERY_LOW: 'very-low',
   LOW: 'low',
   NORMAL: 'normal',
   HIGH: 'high'
 };
-
-module.exports = WebPushConstants;

--- a/src/web-push-error.js
+++ b/src/web-push-error.js
@@ -1,6 +1,6 @@
-'use strict';
+import { inherits } from 'node:util';
 
-function WebPushError(message, statusCode, headers, body, endpoint) {
+export function WebPushError(message, statusCode, headers, body, endpoint) {
   Error.captureStackTrace(this, this.constructor);
 
   this.name = this.constructor.name;
@@ -11,6 +11,4 @@ function WebPushError(message, statusCode, headers, body, endpoint) {
   this.endpoint = endpoint;
 }
 
-require('util').inherits(WebPushError, Error);
-
-module.exports = WebPushError;
+inherits(WebPushError, Error);

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -1,12 +1,11 @@
-'use strict';
+import https from 'node:https';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
-const https = require('https');
-
-const WebPushError = require('./web-push-error.js');
-const vapidHelper = require('./vapid-helper.js');
-const encryptionHelper = require('./encryption-helper.js');
-const webPushConstants = require('./web-push-constants.js');
-const urlBase64Helper = require('./urlsafe-base64-helper');
+import { WebPushError } from './web-push-error.js';
+import * as vapidHelper from './vapid-helper.js';
+import * as encryptionHelper from './encryption-helper.js';
+import * as webPushConstants from './web-push-constants.js';
+import * as urlBase64Helper from './urlsafe-base64-helper.js';
 
 // Default TTL is four weeks.
 const DEFAULT_TTL = 2419200;
@@ -14,7 +13,7 @@ const DEFAULT_TTL = 2419200;
 let gcmAPIKey = '';
 let vapidDetails;
 
-function WebPushLib() {
+export function WebPushLib() {
 
 }
 
@@ -361,7 +360,6 @@ WebPushLib.prototype.sendNotification = function(subscription, payload, options)
       }
 
       if (requestDetails.proxy) {
-        const { HttpsProxyAgent } = require('https-proxy-agent');
         httpsOptions.agent = new HttpsProxyAgent(requestDetails.proxy);
       }
 
@@ -408,5 +406,3 @@ WebPushLib.prototype.sendNotification = function(subscription, payload, options)
       pushRequest.end();
     });
   };
-
-module.exports = WebPushLib;

--- a/test/data/demo/index.html
+++ b/test/data/demo/index.html
@@ -7,7 +7,7 @@
 <body>
   <h1>Test Page</h1>
 
-<script type="text/javascript">
+<script type="module">
 function base64UrlToUint8Array(base64UrlData) {
   const padding = '='.repeat((4 - base64UrlData.length % 4) % 4);
   const base64 = (base64UrlData + padding)
@@ -21,27 +21,23 @@ function base64UrlToUint8Array(base64UrlData) {
   return buffer;
 }
 
-(function() {
-  if (!('serviceWorker' in navigator)) {
-    return;
-  }
-
-  return navigator.serviceWorker.register('service-worker.js')
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('service-worker.js', { type: 'module' })
   .then(function(registration) {
     console.log('service worker registered');
     return navigator.serviceWorker.ready;
   })
   .then(function(reg) {
-    var channel = new MessageChannel();
+    const channel = new MessageChannel();
     channel.port1.onmessage = function(e) {
       window.document.title = e.data;
     }
     reg.active.postMessage('setup', [channel.port2]);
 
-    var subscribeOptions = { userVisibleOnly: true };
+    const subscribeOptions = { userVisibleOnly: true };
     // Figure out the vapid key
-    var searchParam = window.location.search;
-    vapidRegex = searchParam.match(/vapid=(.[^&]*)/);
+    const searchParam = window.location.search;
+    const vapidRegex = searchParam.match(/vapid=(.[^&]*)/);
     if (vapidRegex) {
       // Convert the base 64 encoded string
       subscribeOptions.applicationServerKey = base64UrlToUint8Array(vapidRegex[1]);
@@ -60,7 +56,7 @@ function base64UrlToUint8Array(base64UrlData) {
     window.subscribeSuccess = false;
     window.subscribeError = err;
   });
-})();
+}
 </script>
 </body>
 </html>

--- a/test/data/demo/service-worker.js
+++ b/test/data/demo/service-worker.js
@@ -1,8 +1,3 @@
-/* Needed because of https://github.com/airbnb/javascript/issues/1632 */
-/* eslint no-restricted-globals: 0 */
-
-'use strict';
-
 let port;
 let pushMessage;
 

--- a/test/helpers/create-server.js
+++ b/test/helpers/create-server.js
@@ -1,11 +1,9 @@
-'use strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import portfinder from 'portfinder';
 
-const http = require('http');
-const portfinder = require('portfinder');
-const fs = require('fs');
-const path = require('path');
-
-function createServer() {
+export function createServer() {
   const demoPath = 'test/data/demo';
 
   const server = http.createServer(function(req, res) {
@@ -55,5 +53,3 @@ function createServer() {
     });
   });
 }
-
-module.exports = createServer;

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,15 +1,10 @@
-'use strict';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
 
-(function() {
-  const invalidNodeVersions = /0.(10|12).(\d+)/;
-  if (process.versions.node.match(invalidNodeVersions)) {
-    console.log('Skipping CLI tests as they can\'t run on node: ' + process.versions.node);
-    return;
-  }
-
-  const assert = require('assert');
-  const spawn = require('child_process').spawn;
-
+const invalidNodeVersions = /0.(10|12).(\d+)/;
+if (process.versions.node.match(invalidNodeVersions)) {
+  console.log('Skipping CLI tests as they can\'t run on node: ' + process.versions.node);
+} else {
   const cliPath = 'src/cli.js';
 
   suite('Test CLI', function() {
@@ -192,4 +187,4 @@
       });
     });
   });
-})();
+}

--- a/test/test-encryption-helper.js
+++ b/test/test-encryption-helper.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const assert = require('assert');
-const crypto = require('crypto');
-const webPush = require('../src/index');
-const ece = require('http_ece');
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import ece from 'http_ece';
+import * as webPush from '../src/index.js';
 
 const userCurve = crypto.createECDH('prime256v1');
 const VALID_PUBLIC_KEY = userCurve.generateKeys().toString('base64url');

--- a/test/test-generate-request-details.js
+++ b/test/test-generate-request-details.js
@@ -1,11 +1,10 @@
-'use strict';
-
-const assert = require('assert');
-const { generateRequestDetails } = require('../src/index');
-const crypto = require('crypto');
-const jws = require('jws');
-const urlParse = require('url').parse;
-const https = require('https');
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import { parse as urlParse } from 'node:url';
+import https from 'node:https';
+import jws from 'jws';
+import { generateRequestDetails } from '../src/index.js';
+import * as vapidHelper from '../src/vapid-helper.js';
 
 suite('Test Generate Request Details', function() {
   test('is defined', function() {
@@ -15,7 +14,7 @@ suite('Test Generate Request Details', function() {
   const userCurve = crypto.createECDH('prime256v1');
   const userPublicKey = userCurve.generateKeys();
   const userAuth = crypto.randomBytes(16);
-  const vapidKeys = require('../src/vapid-helper').generateVAPIDKeys();
+  const vapidKeys = vapidHelper.generateVAPIDKeys();
 
   const VALID_KEYS = {
     p256dh: userPublicKey.toString('base64url'),

--- a/test/test-set-vapid-details.js
+++ b/test/test-set-vapid-details.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const assert = require('assert');
-const { setVapidDetails } = require('../src/index');
+import assert from 'node:assert';
+import { setVapidDetails } from '../src/index.js';
 
 const VALID_SUBJECT_MAILTO = 'mailto: example@example.com';
 const VALID_SUBJECT_URL = 'https://exampe.com/contact';

--- a/test/test-vapid-helper.js
+++ b/test/test-vapid-helper.js
@@ -1,11 +1,9 @@
-'use strict';
-
-const assert = require('assert');
-const sinon = require('sinon');
-const crypto = require('crypto');
-const mocha = require('mocha');
-const webPush = require('../src/index');
-const vapidHelper = require('../src/vapid-helper');
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import sinon from 'sinon';
+import mocha from 'mocha';
+import * as webPush from '../src/index.js';
+import * as vapidHelper from '../src/vapid-helper.js';
 
 const VALID_AUDIENCE = 'https://example.com';
 const VALID_SUBJECT_MAILTO = 'mailto:example@example.com';

--- a/test/testBrowsers.js
+++ b/test/testBrowsers.js
@@ -1,11 +1,12 @@
-'use strict';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium, firefox } from 'playwright';
+import * as webPush from '../src/index.js';
+import { createServer } from './helpers/create-server.js';
 
-const { chromium, firefox } = require('playwright');
-const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const webPush = require('../src/index');
-const createServer = require('./helpers/create-server');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const CHROME_CHANNEL = process.env.CHROME_CHANNEL || 'chrome';
 const PUSH_TEST_TIMEOUT = 120 * 1000;

--- a/test/testSendNotification.js
+++ b/test/testSendNotification.js
@@ -1,25 +1,16 @@
-'use strict';
-
-const assert = require('assert');
-const crypto = require('crypto');
-const https = require('https');
-const fs = require('fs');
-const path = require('path');
-const ece = require('http_ece');
-const portfinder = require('portfinder');
-const jws = require('jws');
-const mocha = require('mocha');
-const WebPushConstants = require('../src/web-push-constants.js');
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import https from 'node:https';
+import fs from 'node:fs';
+import ece from 'http_ece';
+import portfinder from 'portfinder';
+import jws from 'jws';
+import mocha from 'mocha';
+import * as WebPushConstants from '../src/web-push-constants.js';
+import { sendNotification, setGCMAPIKey, setVapidDetails } from '../src/index.js';
+import * as vapidHelper from '../src/vapid-helper.js';
 
 suite('sendNotification', function() {
-  let sendNotification;
-  let setGCMAPIKey;
-  let setVapidDetails;
-
-  mocha.beforeEach(function () {
-    ({ sendNotification, setGCMAPIKey, setVapidDetails } = require('../src/index'));
-  });
-
   test('is defined', function() {
     assert(sendNotification);
   });
@@ -43,9 +34,9 @@ suite('sendNotification', function() {
     requestBody = null;
     requestDetails = null;
 
-    // Delete caches of web push libs to start clean between test runs
-    delete require.cache[path.join(__dirname, '..', 'src', 'index.js')];
-    delete require.cache[path.join(__dirname, '..', 'src', 'web-push-lib.js')];
+    // Reset the module-level GCM/VAPID state to start clean between test runs
+    setGCMAPIKey(null);
+    setVapidDetails(null);
 
     // Reset https request mock
     https.request = certHTTPSRequest;
@@ -72,7 +63,7 @@ suite('sendNotification', function() {
     auth: userAuth.toString('base64url')
   };
 
-  const vapidKeys = require('../src/vapid-helper').generateVAPIDKeys();
+  const vapidKeys = vapidHelper.generateVAPIDKeys();
 
   function startServer() {
     const options = {

--- a/test/testSetGCMAPIKey.js
+++ b/test/testSetGCMAPIKey.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const assert = require('assert');
-const { setGCMAPIKey } = require('../src/index');
+import assert from 'node:assert';
+import { setGCMAPIKey } from '../src/index.js';
 
 suite('setGCMAPIKey', function() {
   test('is defined', function() {


### PR DESCRIPTION
Depends on #949 - this PR is stacked so better off reviewing it once that lands, or by commit

This changes the `type` to be `"module"` and rewrites the sources to be ES modules.

All LTS of node (and some previous versions, since 20.x) support `require(esm)` these days. So both CJS and ESM users can import ESM just fine.