### PR TITLE
test: run tests using xvfb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,12 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium firefox
 
-      - name: Run tests
+      - name: Run tests (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run --auto-servernum npm test
+
+      - name: Run tests (macOS)
+        if: runner.os == 'macOS'
         run: npm test
 
       - name: Upload coverage


### PR DESCRIPTION
In order for Linux tests to pass, we need to run chrome with `xvfb-run`
to keep it headed.

Eventually it'd be nice to go headless but it seems Chrome doesn't
enable push in headless mode. `headless: 'new'` may work for that
eventually.
