### PR TITLE
feat: switch CLI to parseArgs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "asn1.js": "^5.3.0",
         "http_ece": "1.2.1",
         "https-proxy-agent": "^9.1.0",
-        "jws": "^4.0.1",
-        "minimist": "^1.2.5"
+        "jws": "^4.0.1"
       },
       "bin": {
         "web-push": "src/cli.js"
@@ -1528,14 +1527,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/minipass": {
       "version": "7.1.3",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "asn1.js": "^5.3.0",
     "http_ece": "1.2.1",
     "https-proxy-agent": "^9.1.0",
-    "jws": "^4.0.1",
-    "minimist": "^1.2.5"
+    "jws": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-import minimist from 'minimist';
+import { parseArgs } from 'node:util';
 
 import * as webPush from '../src/index.js';
 
@@ -76,10 +76,10 @@ const sendNotification = args => {
   const options = {};
 
   if (args.ttl) {
-    options.TTL = args.ttl;
+    options.TTL = Number(args.ttl);
   }
 
-  if (argv['vapid-subject'] || argv['vapid-pubkey'] || argv['vapid-pvtkey']) {
+  if (args['vapid-subject'] || args['vapid-pubkey'] || args['vapid-pvtkey']) {
     options.vapidDetails = {
       subject: args['vapid-subject'] || null,
       publicKey: args['vapid-pubkey'] || null,
@@ -111,19 +111,37 @@ const sendNotification = args => {
   });
 };
 
-const action = process.argv[2];
-const argv = minimist(process.argv.slice(3));
+const { values: args, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  allowPositionals: true,
+  options: {
+    endpoint: { type: 'string' },
+    key: { type: 'string' },
+    auth: { type: 'string' },
+    payload: { type: 'string' },
+    ttl: { type: 'string' },
+    encoding: { type: 'string' },
+    'vapid-subject': { type: 'string' },
+    'vapid-pubkey': { type: 'string' },
+    'vapid-pvtkey': { type: 'string' },
+    proxy: { type: 'string' },
+    'gcm-api-key': { type: 'string' },
+    json: { type: 'boolean' }
+  }
+});
+
+const action = positionals[0];
 switch (action) {
   case 'send-notification':
-    if (!argv.endpoint) {
+    if (!args.endpoint) {
       printUsageDetails();
       break;
     }
 
-    sendNotification(argv);
+    sendNotification(args);
     break;
   case 'generate-vapid-keys':
-    generateVapidKeys(argv.json || false);
+    generateVapidKeys(args.json || false);
     break;
   default:
     printUsageDetails();


### PR DESCRIPTION
We can now use the built-in `parseArgs` feature instead of needing minimist.