### PR TITLE
test: enable firefox testing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,28 +27,14 @@ jobs:
         run: npm install
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      # Playwright's own Firefox build ships without push service keys, so the
-      # tests use a Mozilla build over WebDriver BiDi instead.
-      - name: Install Firefox
-        id: firefox
-        uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
-
-      - name: Install Firefox system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: npx playwright install-deps firefox
+        run: npx playwright install --with-deps chromium firefox
 
       - name: Run tests (Linux)
         if: runner.os == 'Linux'
-        env:
-          FIREFOX_PATH: ${{ steps.firefox.outputs.firefox-path }}
         run: xvfb-run --auto-servernum npm test
 
       - name: Run tests (macOS)
         if: runner.os == 'macOS'
-        env:
-          FIREFOX_PATH: ${{ steps.firefox.outputs.firefox-path }}
         run: npm test
 
       - name: Trust coveralls (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,28 @@ jobs:
         run: npm install
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium firefox
+        run: npx playwright install --with-deps chromium
+
+      # Playwright's own Firefox build ships without push service keys, so the
+      # tests use a Mozilla build over WebDriver BiDi instead.
+      - name: Install Firefox
+        id: firefox
+        uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
+
+      - name: Install Firefox system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps firefox
 
       - name: Run tests (Linux)
         if: runner.os == 'Linux'
+        env:
+          FIREFOX_PATH: ${{ steps.firefox.outputs.firefox-path }}
         run: xvfb-run --auto-servernum npm test
 
       - name: Run tests (macOS)
         if: runner.os == 'macOS'
+        env:
+          FIREFOX_PATH: ${{ steps.firefox.outputs.firefox-path }}
         run: npm test
 
       - name: Trust coveralls (macOS)

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules/
 test/output/
 .nyc_output/
 
-# Chrome profiles created by browser push tests
+# Browser profiles created by browser push tests
 test/.chrome-profile-*
+test/.firefox-profile-*

--- a/test/testBrowsers.js
+++ b/test/testBrowsers.js
@@ -49,6 +49,7 @@ const browsers = [
         executablePath: FIREFOX_PATH,
         headless: false,
         firefoxUserPrefs: {
+          'dom.push.connection.enabled': true,
           'dom.push.testing.ignorePermission': true,
           'notification.prompt.testing': true,
           'notification.prompt.testing.allow': true,

--- a/test/testBrowsers.js
+++ b/test/testBrowsers.js
@@ -10,6 +10,10 @@ import { createServer } from './helpers/create-server.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const CHROME_CHANNEL = process.env.CHROME_CHANNEL || 'chrome';
+// here, `moz-` makes playwright use the system firefox instead of the
+// one playwright ships. The one playwright ships has no push service keys.
+const FIREFOX_CHANNEL = process.env.FIREFOX_CHANNEL || 'moz-firefox';
+const FIREFOX_PATH = process.env.FIREFOX_PATH;
 const PUSH_TEST_TIMEOUT = 120 * 1000;
 const vapidKeys = webPush.generateVAPIDKeys();
 const VAPID_PARAM = {
@@ -39,10 +43,11 @@ const browsers = [
   },
   {
     name: 'Firefox',
-    // Skipped because firefox from playwright does not support push notifications
-    skip: true,
     createContext: async () => {
       const browser = await firefox.launch({
+        channel: FIREFOX_CHANNEL,
+        executablePath: FIREFOX_PATH,
+        headless: false,
         firefoxUserPrefs: {
           'dom.push.testing.ignorePermission': true,
           'notification.prompt.testing': true,
@@ -108,9 +113,7 @@ async function sendNotificationWithRetry(subscription, payload, options, attempt
 }
 
 browsers.forEach(function(browser) {
-  const defineSuite = browser.skip ? suite.skip : suite;
-
-  defineSuite('Playwright ' + browser.name, function() {
+  suite('Playwright ' + browser.name, function() {
     let launched;
     let server;
 

--- a/test/testBrowsers.js
+++ b/test/testBrowsers.js
@@ -10,10 +10,6 @@ import { createServer } from './helpers/create-server.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const CHROME_CHANNEL = process.env.CHROME_CHANNEL || 'chrome';
-// here, `moz-` makes playwright use the system firefox instead of the
-// one playwright ships. The one playwright ships has no push service keys.
-const FIREFOX_CHANNEL = process.env.FIREFOX_CHANNEL || 'moz-firefox';
-const FIREFOX_PATH = process.env.FIREFOX_PATH;
 const PUSH_TEST_TIMEOUT = 120 * 1000;
 const vapidKeys = webPush.generateVAPIDKeys();
 const VAPID_PARAM = {
@@ -44,11 +40,12 @@ const browsers = [
   {
     name: 'Firefox',
     createContext: async () => {
-      const browser = await firefox.launch({
-        channel: FIREFOX_CHANNEL,
-        executablePath: FIREFOX_PATH,
+      const userDataDir = fs.mkdtempSync(path.join(__dirname, '.firefox-profile-'));
+      const context = await firefox.launchPersistentContext(userDataDir, {
         headless: false,
         firefoxUserPrefs: {
+          // Playwright's Firefox build ships without a push server URL set.
+          'dom.push.serverURL': 'wss://push.services.mozilla.com/',
           'dom.push.connection.enabled': true,
           'dom.push.testing.ignorePermission': true,
           'notification.prompt.testing': true,
@@ -56,10 +53,12 @@ const browsers = [
           'permissions.default.desktop-notification': 1
         }
       });
-      const context = await browser.newContext();
       return {
         context,
-        cleanup: () => browser.close()
+        cleanup: async () => {
+          await context.close();
+          fs.rmSync(userDataDir, { recursive: true, force: true });
+        }
       };
     }
   }


### PR DESCRIPTION
It turns out the packaged up firefox does have the ability to use push but has no `pushURL` out of the box.

if we set the `pushURL` and enable `push`, everything works 🎉 

Fixes #962