### PR TITLE
feat: add typescript types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium firefox
 
+      - name: Build
+        run: npm run build
+
       - name: Run tests (Linux)
         if: runner.os == 'Linux'
         run: xvfb-run --auto-servernum npm test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ test/output/
 # Browser profiles created by browser push tests
 test/.chrome-profile-*
 test/.firefox-profile-*
+
+# published tsc output
+/types

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,13 +20,16 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/jws": "^3.2.11",
+        "@types/node": "^26.1.1",
         "c8": "^12.0.0",
         "eslint": "^10.6.0",
         "globals": "^17.6.0",
         "mocha": "^11.7.6",
         "playwright": "^1.61.0",
         "portfinder": "1.0.38",
-        "tinyspy": "^4.0.4"
+        "tinyspy": "^4.0.4",
+        "typescript": "^7.0.2"
       },
       "engines": {
         "node": ">= 16"
@@ -453,6 +456,366 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jws": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/@types/jws/-/jws-3.2.11.tgz",
+      "integrity": "sha512-OOaTrLV6XdF1XvBgMeH1MjNuOaGCrRZWNSIds1AQaRgLdOWlAk2yMsfrJn+ekLgUow3xksWIM231lyFab7mHHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -2272,6 +2635,48 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "web-push": "src/cli.js"
   },
   "scripts": {
+    "build:clean": "node -e \"require('fs').rmSync('./lib', { recursive: true, force: true })\"",
+    "build": "npm run build:clean && tsc",
     "download-browser": "playwright install chromium firefox",
     "lint": "eslint src test",
     "pretest": "npm run lint && npm run download-browser",
@@ -38,13 +40,16 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/jws": "^3.2.11",
+    "@types/node": "^26.1.1",
     "c8": "^12.0.0",
     "eslint": "^10.6.0",
     "globals": "^17.6.0",
     "mocha": "^11.7.6",
     "playwright": "^1.61.0",
     "portfinder": "1.0.38",
-    "tinyspy": "^4.0.4"
+    "tinyspy": "^4.0.4",
+    "typescript": "^7.0.2"
   },
   "engines": {
     "node": ">= 16"

--- a/src/asn1.d.ts
+++ b/src/asn1.d.ts
@@ -1,0 +1,57 @@
+declare module 'asn1.js' {
+  interface Asn1Node {
+    seq(): Asn1Node;
+    obj(...children: Asn1Node[]): Asn1Node;
+    key(name: string): Asn1Node;
+    explicit(tag: number): Asn1Node;
+    optional(): Asn1Node;
+    int(): Asn1Node;
+    octstr(): Asn1Node;
+    objid(): Asn1Node;
+    bitstr(): Asn1Node;
+  }
+
+  interface DecodeOptions {
+    partial?: boolean;
+    track?: (path: string, start: number, end: number, type: string) => void;
+  }
+
+  interface PemOptions {
+    label: string;
+  }
+
+  interface PartialResult<T> {
+    result: T | null;
+    errors: Error[];
+  }
+
+  class Entity<T = unknown> {
+    constructor(name: string, body: (this: Asn1Node) => void);
+
+    decode(
+      data: Buffer,
+      enc: 'der',
+      options: DecodeOptions & { partial: true }
+    ): PartialResult<T>;
+    decode(
+      data: string | Buffer,
+      enc: 'pem',
+      options: PemOptions & DecodeOptions & { partial: true }
+    ): PartialResult<T>;
+    decode(
+      data: string | Buffer,
+      enc: 'pem',
+      options: PemOptions & DecodeOptions
+    ): T;
+    decode(
+      data: Buffer,
+      enc?: 'der',
+      options?: DecodeOptions
+    ): T;
+
+    encode(data: T, enc: 'pem', options: PemOptions): string;
+    encode(data: T, enc?: 'der'): Buffer<ArrayBuffer>;
+  }
+
+  export function define<T = unknown>(name: string, body: (this: Asn1Node) => void): Entity<T>;
+}

--- a/src/encryption-helper.js
+++ b/src/encryption-helper.js
@@ -1,6 +1,13 @@
 import crypto from 'node:crypto';
 import ece from 'http_ece';
 
+/**
+ * @param {string} userPublicKey
+ * @param {string} userAuth
+ * @param {Buffer<ArrayBuffer>|string} payload
+ * @param {string} contentEncoding
+ * @return {{localPublicKey: Buffer<ArrayBuffer>, salt: string, cipherText: Buffer<ArrayBuffer>}}
+ */
 export function encrypt(userPublicKey, userAuth, payload, contentEncoding) {
   if (!userPublicKey) {
     throw new Error('No user public key provided for encryption.');

--- a/src/http_ece.d.ts
+++ b/src/http_ece.d.ts
@@ -1,0 +1,33 @@
+declare module 'http_ece' {
+  import type { ECDH } from 'node:crypto';
+
+  type EncodedBuffer = Buffer<ArrayBuffer> | string;
+
+  interface Params {
+    version?: 'aes128gcm' | 'aesgcm';
+    rs?: number | string;
+    salt?: EncodedBuffer;
+    keyid?: EncodedBuffer;
+    key?: EncodedBuffer;
+    privateKey?: ECDH;
+    keymap?: Record<string, EncodedBuffer>;
+    keylabel?: string;
+    dh?: EncodedBuffer;
+    authSecret?: EncodedBuffer;
+    pad?: number | string;
+  }
+
+  type KeyLookupCallback = (keyid: EncodedBuffer) => Buffer<ArrayBuffer> | undefined;
+
+  export function encrypt(
+    buffer: Buffer<ArrayBuffer>,
+    params: Params,
+    keyLookupCallback?: KeyLookupCallback
+  ): Buffer<ArrayBuffer>;
+
+  export function decrypt(
+    buffer: Buffer<ArrayBuffer>,
+    params: Params,
+    keyLookupCallback?: KeyLookupCallback
+  ): Buffer<ArrayBuffer>;
+}

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -25,6 +25,10 @@ const ECPrivateKeyASN = asn1.define('ECPrivateKey', function() {
   );
 });
 
+/**
+ * @param {Buffer<ArrayBuffer>} key The private key to convert to PEM format.
+ * @return {string} The PEM formatted private key.
+ */
 function toPEM(key) {
   return ECPrivateKeyASN.encode({
     version: 1,
@@ -35,6 +39,9 @@ function toPEM(key) {
   });
 }
 
+/**
+ * @return {({publicKey: string, privateKey: string})} The generated VAPID keys.
+ */
 export function generateVAPIDKeys() {
   const curve = crypto.createECDH('prime256v1');
   curve.generateKeys();
@@ -63,6 +70,10 @@ export function generateVAPIDKeys() {
   };
 }
 
+/**
+ * @param {string} subject The VAPID subject to validate.
+ * @return {void}
+ */
 export function validateSubject(subject) {
   if (!subject) {
     throw new Error('No subject set in vapidDetails.subject.');
@@ -94,6 +105,10 @@ export function validateSubject(subject) {
     }
 }
 
+/**
+ * @param {string} publicKey The VAPID public key to validate.
+ * @return {void}
+ */
 export function validatePublicKey(publicKey) {
   if (!publicKey) {
     throw new Error('No key set vapidDetails.publicKey');
@@ -115,6 +130,10 @@ export function validatePublicKey(publicKey) {
   }
 }
 
+/**
+ * @param {string} privateKey The VAPID private key to validate.
+ * @return {void}
+ */
 export function validatePrivateKey(privateKey) {
   if (!privateKey) {
     throw new Error('No key set in vapidDetails.privateKey');
@@ -141,8 +160,8 @@ export function validatePrivateKey(privateKey) {
  * the expiration in the future by adding the passed `numSeconds`
  * with the current seconds from Unix Epoch
  *
- * @param {Number} numSeconds Number of seconds to be added
- * @return {Number} Future expiration in seconds
+ * @param {number} numSeconds Number of seconds to be added
+ * @return {number} Future expiration in seconds
  */
 export function getFutureExpirationTimestamp(numSeconds) {
   const futureExp = new Date();
@@ -154,7 +173,8 @@ export function getFutureExpirationTimestamp(numSeconds) {
  * Validates the Expiration Header based on the VAPID Spec
  * Throws error of type `Error` if the expiration is not validated
  *
- * @param {Number} expiration Expiration seconds from Epoch to be validated
+ * @param {number} expiration Expiration seconds from Epoch to be validated
+ * @return {void}
  */
 export function validateExpiration(expiration) {
   if (!Number.isInteger(expiration)) {
@@ -175,6 +195,12 @@ export function validateExpiration(expiration) {
 }
 
 /**
+ * @typedef {Object} VapidHeaders
+ * @property {string} Authorization The Authorization header value.
+ * @property {string=} Crypto-Key The Crypto-Key header value.
+ */
+
+/**
  * This method takes the required VAPID parameters and returns the required
  * header to be added to a Web Push Protocol Request.
  * @param  {string} audience        This must be the origin of the push service.
@@ -183,8 +209,8 @@ export function validateExpiration(expiration) {
  * @param  {string} publicKey       The VAPID public key.
  * @param  {string} privateKey      The VAPID private key.
  * @param  {string} contentEncoding The contentEncoding type.
- * @param  {integer} [expiration]   The expiration of the VAPID JWT.
- * @return {Object}                 Returns an Object with the Authorization and
+ * @param  {number=} expiration     The expiration of the VAPID JWT.
+ * @return {VapidHeaders}           Returns an Object with the Authorization and
  * 'Crypto-Key' values to be used as headers.
  */
 export function getVapidHeaders(audience, subject, publicKey, privateKey, contentEncoding, expiration) {

--- a/src/web-push-constants.js
+++ b/src/web-push-constants.js
@@ -1,11 +1,11 @@
-export const supportedContentEncodings = {
+export const supportedContentEncodings = /** @type {const} */ ({
   AES_GCM: 'aesgcm',
   AES_128_GCM: 'aes128gcm'
-};
+});
 
-export const supportedUrgency = {
+export const supportedUrgency = /** @type {const} */ ({
   VERY_LOW: 'very-low',
   LOW: 'low',
   NORMAL: 'normal',
   HIGH: 'high'
-};
+});

--- a/src/web-push-error.js
+++ b/src/web-push-error.js
@@ -1,4 +1,22 @@
 export class WebPushError extends Error {
+  /** @type {string} */
+  name;
+  /** @type {number} */
+  statusCode;
+  /** @type {Record<string, string>} */
+  headers;
+  /** @type {string} */
+  body;
+  /** @type {string} */
+  endpoint;
+
+  /**
+   * @param {string} message
+   * @param {number} statusCode
+   * @param {Record<string, string>} headers
+   * @param {string} body
+   * @param {string} endpoint
+   */
   constructor(message, statusCode, headers, body, endpoint) {
     super(message);
 

--- a/src/web-push-lib.js
+++ b/src/web-push-lib.js
@@ -10,15 +10,54 @@ import * as urlBase64Helper from './urlsafe-base64-helper.js';
 // Default TTL is four weeks.
 const DEFAULT_TTL = 2419200;
 
+/**
+ * @import { supportedUrgency, supportedContentEncodings } from './web-push-constants.js'
+ */
+
+/**
+ * @typedef {Object} VapidDetails
+ * @property {string} subject
+ * @property {string} publicKey
+ * @property {string} privateKey
+ */
+
+/**
+ * @typedef {Object} RequestDetailsOptions
+ * @property {string=} gcmAPIKey
+ * @property {VapidDetails=} vapidDetails
+ * @property {number=} TTL
+ * @property {(typeof supportedContentEncodings[keyof typeof supportedContentEncodings])=} contentEncoding
+ * @property {(typeof supportedUrgency[keyof typeof supportedUrgency])=} urgency
+ * @property {string=} topic
+ * @property {Record<string, string>=} headers
+ * @property {string | URL=} proxy
+ * @property {https.Agent=} agent
+ * @property {number=} timeout
+ */
+
+/**
+ * @typedef {Object} RequestDetails
+ * @property {string} endpoint
+ * @property {string} method
+ * @property {Record<string, string>} headers
+ * @property {Buffer<ArrayBuffer>=} body
+ * @property {string | URL=} proxy
+ * @property {https.Agent=} agent
+ * @property {number=} timeout
+ */
+
+/** @type {string | null} */
 let gcmAPIKey = '';
-let vapidDetails;
+/** @type {null | VapidDetails} */
+let vapidDetails = null;
 
 export class WebPushLib {
   /**
    * When sending messages to a GCM endpoint you need to set the GCM API key
    * by either calling setGMAPIKey() or passing in the API key as an option
    * to sendNotification().
-   * @param  {string} apiKey The API key to send with the GCM request.
+   * @param  {string|null} apiKey The API key to send with the GCM request.
+   * @return {void}
    */
   setGCMAPIKey(apiKey) {
     if (apiKey === null) {
@@ -67,14 +106,14 @@ export class WebPushLib {
    * a push notification call this method.
    *
    * This method will throw an error if there is an issue with the input.
-   * @param  {PushSubscription} subscription The PushSubscription you wish to
+   * @param  {PushSubscription} subscription       The PushSubscription you wish to
    * send the notification to.
-   * @param  {string|Buffer} [payload]       The payload you wish to send to the
+   * @param  {string|Buffer<ArrayBuffer>=} payload The payload you wish to send to the
    * the user.
-   * @param  {Object} [options]              Options for the GCM API key and
+   * @param  {RequestDetailsOptions=} options      Options for the GCM API key and
    * vapid keys can be passed in if they are unique for each notification you
    * wish to send.
-   * @return {Object}                       This method returns an Object which
+   * @return {RequestDetails}                      This method returns an Object which
    * contains 'endpoint', 'method', 'headers' and 'payload'.
    */
   generateRequestDetails(subscription, payload, options) {
@@ -319,16 +358,16 @@ export class WebPushLib {
   /**
    * To send a push notification call this method with a subscription, optional
    * payload and any options.
-   * @param  {PushSubscription} subscription The PushSubscription you wish to
+   * @param  {PushSubscription} subscription       The PushSubscription you wish to
    * send the notification to.
-   * @param  {string|Buffer} [payload]       The payload you wish to send to the
+   * @param  {string|Buffer<ArrayBuffer>=} payload The payload you wish to send to the
    * the user.
-   * @param  {Object} [options]              Options for the GCM API key and
+   * @param  {RequestDetailsOptions=} options      Options for the GCM API key and
    * vapid keys can be passed in if they are unique for each notification you
    * wish to send.
-   * @return {Promise}                       This method returns a Promise which
-   * resolves if the sending of the notification was successful, otherwise it
-   * rejects.
+   * @return {Promise<{statusCode: number; body: string; headers: Record<string, string>}>}
+   * This method returns a Promise which resolves if the sending of the
+   * notification was successful, otherwise it rejects.
    */
   sendNotification(subscription, payload, options) {
     let requestDetails;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "removeComments": true,
+    "allowJs": true,
+    "outDir": "./types",
+    "rootDir": "./src",
+    "module": "node18",
+    "target": "esnext",
+    "types": ["node"],
+    "sourceMap": false,
+    "declaration": true,
+    "declarationMap": false,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strict": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "erasableSyntaxOnly": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds the correct JSDoc so we can use typescript to generate `d.ts` from it.

@marco-c this is more a nice-to-have. we have good enough JSDoc to generate the types so it might be nice to do so and publish them.

if you don't think we should, though, let me know.